### PR TITLE
Make 'why' stand out in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,10 @@ that they are not required to be valid UTF-8.
 
 https://docs.rs/bstr
 
-The documentation includes a section on why you might want to use this crate.
+### When should I use byte string
 
+See this part of the documentation
+https://docs.rs/bstr/0.1.0/bstr/#when-should-i-use-byte-strings.
 
 ### Usage
 


### PR DESCRIPTION
Reading the README, it took me actively looking for it and scrolling up and down to find out **why** someone would use this and not standard library `String` and `str`, I'd venture that not everyone that stumbles across this project knows the implications of 'types that are conventionally UTF-8 for Rust, differ .. in that they are not required to be valid UTF-8'. I was already at the examples and kept asking myself, what problem is this trying to solve? Worse someone could see this, and think this is like the *better* version of std string and starts using it without understanding the nuanced trade offs. That's why I believe the **why** should stand out more. So that even at cursory glance, finding out why one should use this crate becomes easier, without overloading the README with information the reader might already know or deems unimportant.