### PR TITLE
Implement functions for searching bytesets

### DIFF
--- a/bench/Cargo.lock
+++ b/bench/Cargo.lock
@@ -30,7 +30,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "bstr"
-version = "0.1.4"
+version = "0.2.2"
 dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -41,7 +41,7 @@ dependencies = [
 name = "bstr-bench"
 version = "0.0.1"
 dependencies = [
- "bstr 0.1.4",
+ "bstr 0.2.2",
  "criterion 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-segmentation 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/bench/src/bench.rs
+++ b/bench/src/bench.rs
@@ -269,4 +269,6 @@ criterion_group!(g8, trim);
 criterion_group!(g9, search::find_iter);
 criterion_group!(g10, search::rfind_iter);
 criterion_group!(g11, search::find_char);
-criterion_main!(g1, g2, g3, g4, g5, g6, g7, g8, g9, g10, g11);
+criterion_group!(g12, search::find_byteset);
+criterion_group!(g13, search::find_not_byteset);
+criterion_main!(g1, g2, g3, g4, g5, g6, g7, g8, g9, g10, g11, g12, g13);

--- a/bench/src/search.rs
+++ b/bench/src/search.rs
@@ -121,6 +121,137 @@ pub fn find_char(c: &mut Criterion) {
     });
 }
 
+pub fn find_byteset(c: &mut Criterion) {
+    let corpus = SUBTITLE_EN_SMALL;
+    define(c, "bstr/find_byteset/1", "en-small-ascii", corpus, move |b| {
+        let corpus = corpus.as_bytes();
+        b.iter(|| {
+            assert_eq!(None, corpus.find_byteset(b"\0"));
+        });
+    });
+    define(c, "bstr/find_byteset/2", "en-small-ascii", corpus, move |b| {
+        let corpus = corpus.as_bytes();
+        b.iter(|| {
+            assert_eq!(None, corpus.find_byteset(b"\0\xff"));
+        });
+    });
+    define(c, "bstr/find_byteset/3", "en-small-ascii", corpus, move |b| {
+        let corpus = corpus.as_bytes();
+        b.iter(|| {
+            assert_eq!(None, corpus.find_byteset(b"\0\xff\xee"));
+        });
+    });
+    define(c, "bstr/find_byteset/4", "en-small-ascii", corpus, move |b| {
+        let corpus = corpus.as_bytes();
+        b.iter(|| {
+            assert_eq!(None, corpus.find_byteset(b"\0\xff\xee\xdd"));
+        });
+    });
+    define(c, "bstr/find_byteset/10", "en-small-ascii", corpus, move |b| {
+        let corpus = corpus.as_bytes();
+        b.iter(|| {
+            assert_eq!(None, corpus.find_byteset(b"0123456789"));
+        });
+    });
+
+    define(c, "bstr/rfind_byteset/1", "en-small-ascii", corpus, move |b| {
+        let corpus = corpus.as_bytes();
+        b.iter(|| {
+            assert_eq!(None, corpus.rfind_byteset(b"\0"));
+        });
+    });
+    define(c, "bstr/rfind_byteset/2", "en-small-ascii", corpus, move |b| {
+        let corpus = corpus.as_bytes();
+        b.iter(|| {
+            assert_eq!(None, corpus.rfind_byteset(b"\0\xff"));
+        });
+    });
+    define(c, "bstr/rfind_byteset/3", "en-small-ascii", corpus, move |b| {
+        let corpus = corpus.as_bytes();
+        b.iter(|| {
+            assert_eq!(None, corpus.rfind_byteset(b"\0\xff\xee"));
+        });
+    });
+    define(c, "bstr/rfind_byteset/4", "en-small-ascii", corpus, move |b| {
+        let corpus = corpus.as_bytes();
+        b.iter(|| {
+            assert_eq!(None, corpus.rfind_byteset(b"\0\xff\xee\xdd"));
+        });
+    });
+    define(c, "bstr/rfind_byteset/10", "en-small-ascii", corpus, move |b| {
+        let corpus = corpus.as_bytes();
+        b.iter(|| {
+            assert_eq!(None, corpus.rfind_byteset(b"0123456789"));
+        });
+    });
+}
+
+pub fn find_not_byteset(c: &mut Criterion) {
+    let corpus = REPEATED_RARE_SMALL;
+    define(c, "bstr/find_not_byteset/1", "repeated-rare-small", corpus, move |b| {
+        let corpus = corpus.as_bytes();
+        b.iter(|| {
+            assert_eq!(Some(1000), corpus.find_not_byteset(b"z"));
+        })
+    });
+    define(c, "bstr/find_not_byteset/2", "repeated-rare-small", corpus, move |b| {
+        let corpus = corpus.as_bytes();
+        b.iter(|| {
+            assert_eq!(Some(1000), corpus.find_not_byteset(b"zy"));
+        });
+    });
+    define(c, "bstr/find_not_byteset/3", "repeated-rare-small", corpus, move |b| {
+        let corpus = corpus.as_bytes();
+        b.iter(|| {
+            assert_eq!(Some(1000), corpus.find_not_byteset(b"zyx"));
+        });
+    });
+    define(c, "bstr/find_not_byteset/4", "repeated-rare-small", corpus, move |b| {
+        let corpus = corpus.as_bytes();
+        b.iter(|| {
+            assert_eq!(Some(1000), corpus.find_not_byteset(b"zyxw"));
+        });
+    });
+    define(c, "bstr/find_not_byteset/10", "repeated-rare-small", corpus, move |b| {
+        let corpus = corpus.as_bytes();
+        b.iter(|| {
+            assert_eq!(Some(1000), corpus.find_not_byteset(b"zyxwv12345"));
+        });
+    });
+
+    define(c, "bstr/rfind_not_byteset/1", "repeated-rare-small", corpus, move |b| {
+        // This file ends in \n, breaking our benchmark.... TODO find a better dataset...
+        let corpus = &corpus.as_bytes()[..(corpus.len()-1)];
+        b.iter(|| {
+            assert_eq!(None, corpus.rfind_not_byteset(b"z"));
+        });
+    });
+    define(c, "bstr/rfind_not_byteset/2", "repeated-rare-small", corpus, move |b| {
+        let corpus = corpus.as_bytes();
+        b.iter(|| {
+            assert_eq!(None, corpus.rfind_not_byteset(b"z\n"));
+        });
+    });
+    define(c, "bstr/rfind_not_byteset/3", "repeated-rare-small", corpus, move |b| {
+        let corpus = corpus.as_bytes();
+        b.iter(|| {
+            assert_eq!(None, corpus.rfind_not_byteset(b"zy\n"));
+        });
+    });
+    define(c, "bstr/rfind_not_byteset/4", "repeated-rare-small", corpus, move |b| {
+        let corpus = corpus.as_bytes();
+        b.iter(|| {
+            assert_eq!(None, corpus.rfind_not_byteset(b"zyx\n"));
+        });
+    });
+    define(c, "bstr/rfind_not_byteset/10", "repeated-rare-small", corpus, move |b| {
+        let corpus = corpus.as_bytes();
+        b.iter(|| {
+            assert_eq!(None, corpus.rfind_not_byteset(b"zyxwv1234\n"));
+        });
+    });
+}
+
 fn define_find_iter(
     c: &mut Criterion,
     group_name: &str,

--- a/src/byteset/mod.rs
+++ b/src/byteset/mod.rs
@@ -83,17 +83,33 @@ pub(crate) fn rfind_not(haystack: &[u8], byteset: &[u8]) -> Option<usize> {
 mod tests {
 
     quickcheck! {
-        fn qc_byteset_forward_matches_naive(haystack: Vec<u8>, needles: Vec<u8>) -> bool {
-            super::find(&haystack, &needles) == haystack.iter().position(|b| needles.contains(b))
+        fn qc_byteset_forward_matches_naive(
+            haystack: Vec<u8>,
+            needles: Vec<u8>
+        ) -> bool {
+            super::find(&haystack, &needles)
+                == haystack.iter().position(|b| needles.contains(b))
         }
-        fn qc_byteset_backwards_matches_naive(haystack: Vec<u8>, needles: Vec<u8>) -> bool {
-            super::rfind(&haystack, &needles) == haystack.iter().rposition(|b| needles.contains(b))
+        fn qc_byteset_backwards_matches_naive(
+            haystack: Vec<u8>,
+            needles: Vec<u8>
+        ) -> bool {
+            super::rfind(&haystack, &needles)
+                == haystack.iter().rposition(|b| needles.contains(b))
         }
-        fn qc_byteset_forward_not_matches_naive(haystack: Vec<u8>, needles: Vec<u8>) -> bool {
-            super::find_not(&haystack, &needles) == haystack.iter().position(|b| !needles.contains(b))
+        fn qc_byteset_forward_not_matches_naive(
+            haystack: Vec<u8>,
+            needles: Vec<u8>
+        ) -> bool {
+            super::find_not(&haystack, &needles)
+                == haystack.iter().position(|b| !needles.contains(b))
         }
-        fn qc_byteset_backwards_not_matches_naive(haystack: Vec<u8>, needles: Vec<u8>) -> bool {
-            super::rfind_not(&haystack, &needles) == haystack.iter().rposition(|b| !needles.contains(b))
+        fn qc_byteset_backwards_not_matches_naive(
+            haystack: Vec<u8>,
+            needles: Vec<u8>
+        ) -> bool {
+            super::rfind_not(&haystack, &needles)
+                == haystack.iter().rposition(|b| !needles.contains(b))
         }
     }
 }

--- a/src/byteset/mod.rs
+++ b/src/byteset/mod.rs
@@ -1,0 +1,142 @@
+use memchr::{memchr, memchr2, memchr3, memrchr, memrchr2, memrchr3};
+mod scalar;
+
+#[inline]
+fn build_table(byteset: &[u8]) -> [u8; 256] {
+    let mut table = [0u8; 256];
+    for &b in byteset {
+        table[b as usize] = 1;
+    }
+    table
+}
+
+#[inline]
+fn should_use_table(set_size: usize) -> bool {
+    // This probably should depend on `size_of::<usize>` as well as the size
+    // of `haystack`.
+    set_size >= 4
+}
+
+#[inline]
+pub(crate) fn find(haystack: &[u8], byteset: &[u8]) -> Option<usize> {
+    match byteset.len() {
+        0 => return None,
+        1 => memchr(byteset[0], haystack),
+        2 => memchr2(byteset[0], byteset[1], haystack),
+        3 => memchr3(byteset[0], byteset[1], byteset[2], haystack),
+        n => {
+            if should_use_table(n) {
+                let table = build_table(byteset);
+                scalar::forward_search_bytes(haystack, |b| {
+                    table[b as usize] != 0
+                })
+            } else {
+                scalar::forward_search_bytes(haystack, |b| {
+                    scalar::forward_search_bytes(byteset, |sb| b == sb)
+                        .is_some()
+                })
+            }
+        }
+    }
+}
+
+#[inline]
+pub(crate) fn rfind(haystack: &[u8], byteset: &[u8]) -> Option<usize> {
+    match byteset.len() {
+        0 => return None,
+        1 => memrchr(byteset[0], haystack),
+        2 => memrchr2(byteset[0], byteset[1], haystack),
+        3 => memrchr3(byteset[0], byteset[1], byteset[2], haystack),
+        n => {
+            if should_use_table(n) {
+                let table = build_table(byteset);
+                scalar::reverse_search_bytes(haystack, |b| {
+                    table[b as usize] != 0
+                })
+            } else {
+                scalar::reverse_search_bytes(haystack, |b| {
+                    scalar::forward_search_bytes(byteset, |sb| b == sb)
+                        .is_some()
+                })
+            }
+        }
+    }
+}
+
+#[inline]
+pub(crate) fn find_not(haystack: &[u8], byteset: &[u8]) -> Option<usize> {
+    if haystack.is_empty() {
+        return None;
+    }
+    match byteset.len() {
+        0 => return Some(0),
+        1 => scalar::inv_memchr(byteset[0], haystack),
+        2 => scalar::forward_search_bytes(haystack, |b| {
+            b != byteset[0] && b != byteset[1]
+        }),
+        3 => scalar::forward_search_bytes(haystack, |b| {
+            b != byteset[0] && b != byteset[1] && b != byteset[2]
+        }),
+        n => {
+            if should_use_table(n) {
+                let table = build_table(byteset);
+                scalar::forward_search_bytes(haystack, |b| {
+                    table[b as usize] == 0
+                })
+            } else {
+                scalar::forward_search_bytes(haystack, |b| {
+                    scalar::forward_search_bytes(byteset, |sb| b != sb)
+                        .is_some()
+                })
+            }
+        }
+    }
+}
+#[inline]
+pub(crate) fn rfind_not(haystack: &[u8], byteset: &[u8]) -> Option<usize> {
+    if haystack.is_empty() {
+        return None;
+    }
+    match byteset.len() {
+        0 => return Some(haystack.len() - 1),
+        1 => scalar::inv_memrchr(byteset[0], haystack),
+        2 => scalar::reverse_search_bytes(haystack, |b| {
+            b != byteset[0] && b != byteset[1]
+        }),
+        3 => scalar::reverse_search_bytes(haystack, |b| {
+            b != byteset[0] && b != byteset[1] && b != byteset[2]
+        }),
+        n => {
+            if should_use_table(n) {
+                let table = build_table(byteset);
+                scalar::reverse_search_bytes(haystack, |b| {
+                    table[b as usize] == 0
+                })
+            } else {
+                scalar::reverse_search_bytes(haystack, |b| {
+                    scalar::forward_search_bytes(byteset, |sb| b != sb)
+                        .is_some()
+                })
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    quickcheck! {
+        fn qc_byteset_forward_matches_naive(haystack: Vec<u8>, needles: Vec<u8>) -> bool {
+            super::find(&haystack, &needles) == haystack.iter().position(|b| needles.contains(b))
+        }
+        fn qc_byteset_backwards_matches_naive(haystack: Vec<u8>, needles: Vec<u8>) -> bool {
+            super::rfind(&haystack, &needles) == haystack.iter().rposition(|b| needles.contains(b))
+        }
+        fn qc_byteset_forward_not_matches_naive(haystack: Vec<u8>, needles: Vec<u8>) -> bool {
+            super::find_not(&haystack, &needles) == haystack.iter().position(|b| !needles.contains(b))
+        }
+        fn qc_byteset_backwards_not_matches_naive(haystack: Vec<u8>, needles: Vec<u8>) -> bool {
+            super::rfind_not(&haystack, &needles) == haystack.iter().rposition(|b| !needles.contains(b))
+        }
+    }
+}

--- a/src/byteset/mod.rs
+++ b/src/byteset/mod.rs
@@ -11,31 +11,15 @@ fn build_table(byteset: &[u8]) -> [u8; 256] {
 }
 
 #[inline]
-fn should_use_table(set_size: usize) -> bool {
-    // This probably should depend on `size_of::<usize>` as well as the size
-    // of `haystack`.
-    set_size >= 4
-}
-
-#[inline]
 pub(crate) fn find(haystack: &[u8], byteset: &[u8]) -> Option<usize> {
     match byteset.len() {
         0 => return None,
         1 => memchr(byteset[0], haystack),
         2 => memchr2(byteset[0], byteset[1], haystack),
         3 => memchr3(byteset[0], byteset[1], byteset[2], haystack),
-        n => {
-            if should_use_table(n) {
-                let table = build_table(byteset);
-                scalar::forward_search_bytes(haystack, |b| {
-                    table[b as usize] != 0
-                })
-            } else {
-                scalar::forward_search_bytes(haystack, |b| {
-                    scalar::forward_search_bytes(byteset, |sb| b == sb)
-                        .is_some()
-                })
-            }
+        _ => {
+            let table = build_table(byteset);
+            scalar::forward_search_bytes(haystack, |b| table[b as usize] != 0)
         }
     }
 }
@@ -47,18 +31,9 @@ pub(crate) fn rfind(haystack: &[u8], byteset: &[u8]) -> Option<usize> {
         1 => memrchr(byteset[0], haystack),
         2 => memrchr2(byteset[0], byteset[1], haystack),
         3 => memrchr3(byteset[0], byteset[1], byteset[2], haystack),
-        n => {
-            if should_use_table(n) {
-                let table = build_table(byteset);
-                scalar::reverse_search_bytes(haystack, |b| {
-                    table[b as usize] != 0
-                })
-            } else {
-                scalar::reverse_search_bytes(haystack, |b| {
-                    scalar::forward_search_bytes(byteset, |sb| b == sb)
-                        .is_some()
-                })
-            }
+        _ => {
+            let table = build_table(byteset);
+            scalar::reverse_search_bytes(haystack, |b| table[b as usize] != 0)
         }
     }
 }
@@ -77,18 +52,9 @@ pub(crate) fn find_not(haystack: &[u8], byteset: &[u8]) -> Option<usize> {
         3 => scalar::forward_search_bytes(haystack, |b| {
             b != byteset[0] && b != byteset[1] && b != byteset[2]
         }),
-        n => {
-            if should_use_table(n) {
-                let table = build_table(byteset);
-                scalar::forward_search_bytes(haystack, |b| {
-                    table[b as usize] == 0
-                })
-            } else {
-                scalar::forward_search_bytes(haystack, |b| {
-                    scalar::forward_search_bytes(byteset, |sb| b != sb)
-                        .is_some()
-                })
-            }
+        _ => {
+            let table = build_table(byteset);
+            scalar::forward_search_bytes(haystack, |b| table[b as usize] == 0)
         }
     }
 }
@@ -106,18 +72,9 @@ pub(crate) fn rfind_not(haystack: &[u8], byteset: &[u8]) -> Option<usize> {
         3 => scalar::reverse_search_bytes(haystack, |b| {
             b != byteset[0] && b != byteset[1] && b != byteset[2]
         }),
-        n => {
-            if should_use_table(n) {
-                let table = build_table(byteset);
-                scalar::reverse_search_bytes(haystack, |b| {
-                    table[b as usize] == 0
-                })
-            } else {
-                scalar::reverse_search_bytes(haystack, |b| {
-                    scalar::forward_search_bytes(byteset, |sb| b != sb)
-                        .is_some()
-                })
-            }
+        _ => {
+            let table = build_table(byteset);
+            scalar::reverse_search_bytes(haystack, |b| table[b as usize] == 0)
         }
     }
 }

--- a/src/byteset/scalar.rs
+++ b/src/byteset/scalar.rs
@@ -1,0 +1,190 @@
+// This is adapted from `fallback.rs` from rust-memchr. It's modified to return
+// the 'inverse' query of memchr, e.g. finding the first byte not in the provided
+// set. This is simple for the 1-byte case.
+
+use core::cmp;
+use core::ptr;
+use core::usize;
+
+#[cfg(target_pointer_width = "32")]
+const USIZE_BYTES: usize = 4;
+
+#[cfg(target_pointer_width = "64")]
+const USIZE_BYTES: usize = 8;
+
+// The number of bytes to loop at in one iteration of memchr/memrchr.
+const LOOP_SIZE: usize = 2 * USIZE_BYTES;
+
+/// Repeat the given byte into a word size number. That is, every 8 bits
+/// is equivalent to the given byte. For example, if `b` is `\x4E` or
+/// `01001110` in binary, then the returned value on a 32-bit system would be:
+/// `01001110_01001110_01001110_01001110`.
+#[inline(always)]
+fn repeat_byte(b: u8) -> usize {
+    (b as usize) * (usize::MAX / 255)
+}
+
+pub fn inv_memchr(n1: u8, haystack: &[u8]) -> Option<usize> {
+    let vn1 = repeat_byte(n1);
+    let confirm = |byte| byte != n1;
+    let loop_size = cmp::min(LOOP_SIZE, haystack.len());
+    let align = USIZE_BYTES - 1;
+    let start_ptr = haystack.as_ptr();
+    let end_ptr = haystack[haystack.len()..].as_ptr();
+    let mut ptr = start_ptr;
+
+    unsafe {
+        if haystack.len() < USIZE_BYTES {
+            return forward_search(start_ptr, end_ptr, ptr, confirm);
+        }
+
+        let chunk = read_unaligned_usize(ptr);
+        if (chunk ^ vn1) != 0 {
+            return forward_search(start_ptr, end_ptr, ptr, confirm);
+        }
+
+        ptr = ptr_add(ptr, USIZE_BYTES - (start_ptr as usize & align));
+        debug_assert!(ptr > start_ptr);
+        debug_assert!(ptr_sub(end_ptr, USIZE_BYTES) >= start_ptr);
+        while loop_size == LOOP_SIZE && ptr <= ptr_sub(end_ptr, loop_size) {
+            debug_assert_eq!(0, (ptr as usize) % USIZE_BYTES);
+
+            let a = *(ptr as *const usize);
+            let b = *(ptr_add(ptr, USIZE_BYTES) as *const usize);
+            let eqa = (a ^ vn1) != 0;
+            let eqb = (b ^ vn1) != 0;
+            if eqa || eqb {
+                break;
+            }
+            ptr = ptr_add(ptr, LOOP_SIZE);
+        }
+        forward_search(start_ptr, end_ptr, ptr, confirm)
+    }
+}
+
+/// Return the last index not matching the byte `x` in `text`.
+pub fn inv_memrchr(n1: u8, haystack: &[u8]) -> Option<usize> {
+    let vn1 = repeat_byte(n1);
+    let confirm = |byte| byte != n1;
+    let loop_size = cmp::min(LOOP_SIZE, haystack.len());
+    let align = USIZE_BYTES - 1;
+    let start_ptr = haystack.as_ptr();
+    let end_ptr = haystack[haystack.len()..].as_ptr();
+    let mut ptr = end_ptr;
+
+    unsafe {
+        if haystack.len() < USIZE_BYTES {
+            return reverse_search(start_ptr, end_ptr, ptr, confirm);
+        }
+
+        let chunk = read_unaligned_usize(ptr_sub(ptr, USIZE_BYTES));
+        if (chunk ^ vn1) != 0 {
+            return reverse_search(start_ptr, end_ptr, ptr, confirm);
+        }
+
+        ptr = (end_ptr as usize & !align) as *const u8;
+        debug_assert!(start_ptr <= ptr && ptr <= end_ptr);
+        while loop_size == LOOP_SIZE && ptr >= ptr_add(start_ptr, loop_size) {
+            debug_assert_eq!(0, (ptr as usize) % USIZE_BYTES);
+
+            let a = *(ptr_sub(ptr, 2 * USIZE_BYTES) as *const usize);
+            let b = *(ptr_sub(ptr, 1 * USIZE_BYTES) as *const usize);
+            let eqa = (a ^ vn1) != 0;
+            let eqb = (b ^ vn1) != 0;
+            if eqa || eqb {
+                break;
+            }
+            ptr = ptr_sub(ptr, loop_size);
+        }
+        reverse_search(start_ptr, end_ptr, ptr, confirm)
+    }
+}
+
+#[inline(always)]
+unsafe fn forward_search<F: Fn(u8) -> bool>(
+    start_ptr: *const u8,
+    end_ptr: *const u8,
+    mut ptr: *const u8,
+    confirm: F,
+) -> Option<usize> {
+    debug_assert!(start_ptr <= ptr);
+    debug_assert!(ptr <= end_ptr);
+
+    while ptr < end_ptr {
+        if confirm(*ptr) {
+            return Some(sub(ptr, start_ptr));
+        }
+        ptr = ptr.offset(1);
+    }
+    None
+}
+
+#[inline(always)]
+unsafe fn reverse_search<F: Fn(u8) -> bool>(
+    start_ptr: *const u8,
+    end_ptr: *const u8,
+    mut ptr: *const u8,
+    confirm: F,
+) -> Option<usize> {
+    debug_assert!(start_ptr <= ptr);
+    debug_assert!(ptr <= end_ptr);
+
+    while ptr > start_ptr {
+        ptr = ptr.offset(-1);
+        if confirm(*ptr) {
+            return Some(sub(ptr, start_ptr));
+        }
+    }
+    None
+}
+
+/// Increment the given pointer by the given amount.
+unsafe fn ptr_add(ptr: *const u8, amt: usize) -> *const u8 {
+    debug_assert!(amt < ::core::isize::MAX as usize);
+    ptr.offset(amt as isize)
+}
+
+/// Decrement the given pointer by the given amount.
+unsafe fn ptr_sub(ptr: *const u8, amt: usize) -> *const u8 {
+    debug_assert!(amt < ::core::isize::MAX as usize);
+    ptr.offset((amt as isize).wrapping_neg())
+}
+
+unsafe fn read_unaligned_usize(ptr: *const u8) -> usize {
+    let mut n: usize = 0;
+    ptr::copy_nonoverlapping(ptr, &mut n as *mut _ as *mut u8, USIZE_BYTES);
+    n
+}
+
+/// Subtract `b` from `a` and return the difference. `a` should be greater than
+/// or equal to `b`.
+fn sub(a: *const u8, b: *const u8) -> usize {
+    debug_assert!(a >= b);
+    (a as usize) - (b as usize)
+}
+
+/// Safe wrapper around `forward_search`
+#[inline]
+pub(super) fn forward_search_bytes<F: Fn(u8) -> bool>(
+    s: &[u8],
+    confirm: F,
+) -> Option<usize> {
+    unsafe {
+        let start = s.as_ptr();
+        let end = start.add(s.len());
+        forward_search(start, end, start, confirm)
+    }
+}
+
+/// Safe wrapper around `reverse_search`
+#[inline]
+pub(super) fn reverse_search_bytes<F: Fn(u8) -> bool>(
+    s: &[u8],
+    confirm: F,
+) -> Option<usize> {
+    unsafe {
+        let start = s.as_ptr();
+        let end = start.add(s.len());
+        reverse_search(start, end, end, confirm)
+    }
+}

--- a/src/ext_slice.rs
+++ b/src/ext_slice.rs
@@ -655,7 +655,8 @@ pub trait ByteSlice: Sealed {
     /// The `byteset` may be any type that can be cheaply converted into a
     /// `&[u8]`. This includes, but is not limited to, `&str` and `&[u8]`, but
     /// note that passing a `&str` which contains multibyte characters may not
-    /// behave as you expect.
+    /// behave as you expect: each byte in the `&str` is treated as an
+    /// individual member of the byte set.
     ///
     /// Note that order is irrelevant for the `byteset` parameter, and
     /// duplicate bytes present in its body are ignored.
@@ -685,13 +686,14 @@ pub trait ByteSlice: Sealed {
         byteset::find(self.as_bytes(), byteset.as_ref())
     }
 
-    /// Returns the index of the first occurrence of any of the bytes in the
-    /// provided set.
+    /// Returns the index of the first occurrence of a byte that is not a member
+    /// of the provided set.
     ///
     /// The `byteset` may be any type that can be cheaply converted into a
     /// `&[u8]`. This includes, but is not limited to, `&str` and `&[u8]`, but
     /// note that passing a `&str` which contains multibyte characters may not
-    /// behave as you expect.
+    /// behave as you expect: each byte in the `&str` is treated as an
+    /// individual member of the byte set.
     ///
     /// Note that order is irrelevant for the `byteset` parameter, and
     /// duplicate bytes present in its body are ignored.
@@ -721,13 +723,14 @@ pub trait ByteSlice: Sealed {
         byteset::find_not(self.as_bytes(), byteset.as_ref())
     }
 
-    /// Returns the index of the first occurrence of a byte that is not a member
-    /// of the provided set.
+    /// Returns the index of the last occurrence of any of the bytes in the
+    /// provided set.
     ///
     /// The `byteset` may be any type that can be cheaply converted into a
     /// `&[u8]`. This includes, but is not limited to, `&str` and `&[u8]`, but
     /// note that passing a `&str` which contains multibyte characters may not
-    /// behave as you expect.
+    /// behave as you expect: each byte in the `&str` is treated as an
+    /// individual member of the byte set.
     ///
     /// Note that order is irrelevant for the `byteset` parameter, and duplicate
     /// bytes present in its body are ignored.
@@ -763,7 +766,8 @@ pub trait ByteSlice: Sealed {
     /// The `byteset` may be any type that can be cheaply converted into a
     /// `&[u8]`. This includes, but is not limited to, `&str` and `&[u8]`, but
     /// note that passing a `&str` which contains multibyte characters may not
-    /// behave as you expect.
+    /// behave as you expect: each byte in the `&str` is treated as an
+    /// individual member of the byte set.
     ///
     /// Note that order is irrelevant for the `byteset` parameter, and
     /// duplicate bytes present in its body are ignored.

--- a/src/ext_slice.rs
+++ b/src/ext_slice.rs
@@ -15,6 +15,7 @@ use memchr::{memchr, memrchr};
 
 use ascii;
 use bstr::BStr;
+use byteset;
 #[cfg(feature = "std")]
 use ext_vec::ByteVec;
 use search::{PrefilterState, TwoWay};
@@ -646,6 +647,150 @@ pub trait ByteSlice: Sealed {
     #[inline]
     fn ends_with_str<B: AsRef<[u8]>>(&self, suffix: B) -> bool {
         self.as_bytes().ends_with(suffix.as_ref())
+    }
+
+    /// Returns the index of the first occurrence of any of the bytes in the
+    /// provided set.
+    ///
+    /// The `byteset` may be any type that can be cheaply converted into a
+    /// `&[u8]`. This includes, but is not limited to, `&str` and `&[u8]`, but
+    /// note that passing a `&str` which contains multibyte characters may not
+    /// behave as you expect.
+    ///
+    /// Note that order is irrelevant for the `byteset` parameter, and
+    /// duplicate bytes present in its body are ignored.
+    ///
+    /// # Complexity
+    ///
+    /// This routine is guaranteed to have worst case linear time complexity
+    /// with respect to both the set of bytes and the haystack. That is, this
+    /// runs in `O(byteset.len() + haystack.len())` time.
+    ///
+    /// This routine is also guaranteed to have worst case constant space
+    /// complexity.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// use bstr::ByteSlice;
+    ///
+    /// assert_eq!(b"foo bar baz".find_byteset(b"zr"), Some(6));
+    /// assert_eq!(b"foo baz bar".find_byteset(b"bzr"), Some(4));
+    /// assert_eq!(None, b"foo baz bar".find_byteset(b"\t\n"));
+    /// ```
+    #[inline]
+    fn find_byteset<B: AsRef<[u8]>>(&self, byteset: B) -> Option<usize> {
+        byteset::find(self.as_bytes(), byteset.as_ref())
+    }
+
+    /// Returns the index of the first occurrence of any of the bytes in the
+    /// provided set.
+    ///
+    /// The `byteset` may be any type that can be cheaply converted into a
+    /// `&[u8]`. This includes, but is not limited to, `&str` and `&[u8]`, but
+    /// note that passing a `&str` which contains multibyte characters may not
+    /// behave as you expect.
+    ///
+    /// Note that order is irrelevant for the `byteset` parameter, and
+    /// duplicate bytes present in its body are ignored.
+    ///
+    /// # Complexity
+    ///
+    /// This routine is guaranteed to have worst case linear time complexity
+    /// with respect to both the set of bytes and the haystack. That is, this
+    /// runs in `O(byteset.len() + haystack.len())` time.
+    ///
+    /// This routine is also guaranteed to have worst case constant space
+    /// complexity.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// use bstr::ByteSlice;
+    ///
+    /// assert_eq!(b"foo bar baz".find_not_byteset(b"fo "), Some(4));
+    /// assert_eq!(b"\t\tbaz bar".find_not_byteset(b" \t\r\n"), Some(2));
+    /// assert_eq!(b"foo\nbaz\tbar".find_not_byteset(b"\t\n"), Some(0));
+    /// ```
+    #[inline]
+    fn find_not_byteset<B: AsRef<[u8]>>(&self, byteset: B) -> Option<usize> {
+        byteset::find_not(self.as_bytes(), byteset.as_ref())
+    }
+
+    /// Returns the index of the first occurrence of a byte that is not a member
+    /// of the provided set.
+    ///
+    /// The `byteset` may be any type that can be cheaply converted into a
+    /// `&[u8]`. This includes, but is not limited to, `&str` and `&[u8]`, but
+    /// note that passing a `&str` which contains multibyte characters may not
+    /// behave as you expect.
+    ///
+    /// Note that order is irrelevant for the `byteset` parameter, and duplicate
+    /// bytes present in its body are ignored.
+    ///
+    /// # Complexity
+    ///
+    /// This routine is guaranteed to have worst case linear time complexity
+    /// with respect to both the set of bytes and the haystack. That is, this
+    /// runs in `O(byteset.len() + haystack.len())` time.
+    ///
+    /// This routine is also guaranteed to have worst case constant space
+    /// complexity.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// use bstr::ByteSlice;
+    ///
+    /// assert_eq!(b"foo bar baz".rfind_byteset(b"agb"), Some(9));
+    /// assert_eq!(b"foo baz bar".rfind_byteset(b"rabz "), Some(10));
+    /// assert_eq!(b"foo baz bar".rfind_byteset(b"\n123"), None);
+    /// ```
+    #[inline]
+    fn rfind_byteset<B: AsRef<[u8]>>(&self, byteset: B) -> Option<usize> {
+        byteset::rfind(self.as_bytes(), byteset.as_ref())
+    }
+
+    /// Returns the index of the last occurrence of a byte that is not a member
+    /// of the provided set.
+    ///
+    /// The `byteset` may be any type that can be cheaply converted into a
+    /// `&[u8]`. This includes, but is not limited to, `&str` and `&[u8]`, but
+    /// note that passing a `&str` which contains multibyte characters may not
+    /// behave as you expect.
+    ///
+    /// Note that order is irrelevant for the `byteset` parameter, and
+    /// duplicate bytes present in its body are ignored.
+    ///
+    /// # Complexity
+    ///
+    /// This routine is guaranteed to have worst case linear time complexity
+    /// with respect to both the set of bytes and the haystack. That is, this
+    /// runs in `O(byteset.len() + haystack.len())` time.
+    ///
+    /// This routine is also guaranteed to have worst case constant space
+    /// complexity.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// use bstr::ByteSlice;
+    ///
+    /// assert_eq!(b"foo bar baz,\t".rfind_not_byteset(b",\t"), Some(10));
+    /// assert_eq!(b"foo baz bar".rfind_not_byteset(b"rabz "), Some(2));
+    /// assert_eq!(None, b"foo baz bar".rfind_not_byteset(b"barfoz "));
+    /// ```
+    #[inline]
+    fn rfind_not_byteset<B: AsRef<[u8]>>(&self, byteset: B) -> Option<usize> {
+        byteset::rfind_not(self.as_bytes(), byteset.as_ref())
     }
 
     /// Returns the index of the first occurrence of the given needle.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -409,6 +409,7 @@ mod ascii;
 mod bstr;
 #[cfg(feature = "std")]
 mod bstring;
+mod byteset;
 mod cow;
 mod ext_slice;
 mod ext_vec;


### PR DESCRIPTION
Sorry this took so long. I didn't end up doing any SIMD-optimized versions, but I did optimize the single-byte version of the find_not predicate using SWAR-ish operations taken more or less from `memchr` with a few modifications to make the conditions inverted.

It was not clear to me how to implement the 2-byte and 3-byte versions of the find_not functions in the same manner (although I'm probably just not being sufficiently clever).

It includes benchmarks, but not terribly robust ones.

Fixes #13