### PR TITLE
Make generate-unicode-data work on places other than andrew's machine

### DIFF
--- a/scripts/generate-unicode-data
+++ b/scripts/generate-unicode-data
@@ -130,15 +130,19 @@ main() {
     # ucd-generate is used to compile regexes into DFAs.
     requires ucd-generate
 
+    mkdir -p src/unicode/fsm/
+
     # For development when ucd-generate needs to be updated.
-    cargo install -f --path /home/andrew/rust/ucd-generate
+    #cargo install -f --path /home/andrew/rust/ucd-generate
 
     all=
     if [ $# -eq 0 ] || array_exists "all" "$@"; then
-        all=yes
+        all=$commands
     fi
-    for cmd in "$@"; do
-        if [ -n "$all" ] || array_exists "$cmd" $commands; then
+    for cmd in "$@" $all; do
+        if [ "$cmd" = "all" ]; then
+            continue
+        elif array_exists "$cmd" $commands; then
             fun="$(echo "$cmd" | sed 's/-/_/g')"
             eval "$fun"
         else


### PR DESCRIPTION
Debian FTP masters are asking us to ensure that code that is claimed to be autogenerated from a particular command, is indeed actually autogenerate by that command. The easiest way to do that is to actually run the command, hence this PR.