### PR TITLE
Expose first_non_ascii_byte as a find_ method on ByteSlice

### DIFF
--- a/src/ext_slice.rs
+++ b/src/ext_slice.rs
@@ -2831,6 +2831,31 @@ pub trait ByteSlice: Sealed {
         bytes.get(bytes.len().saturating_sub(1)).map(|&b| b)
     }
 
+    /// Returns the index of the first non-ASCII byte in this byte string (if
+    /// any such indices exist). Specifically, it returns the index of the
+    /// first byte with a value greater than or equal to `0x80`.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// use bstr::{ByteSlice, B};
+    ///
+    /// assert_eq!(Some(3), b"abc\xff".find_non_ascii_byte());
+    /// assert_eq!(None, b"abcde".find_non_ascii_byte());
+    /// assert_eq!(Some(0), B("😀").find_non_ascii_byte());
+    /// ```
+    #[inline]
+    fn find_non_ascii_byte(&self) -> Option<usize> {
+        let index = ascii::first_non_ascii_byte(self.as_bytes());
+        if index == self.as_bytes().len() {
+            None
+        } else {
+            Some(index)
+        }
+    }
+
     /// Copies elements from one part of the slice to another part of itself,
     /// where the parts may be overlapping.
     ///


### PR DESCRIPTION
In the repo I work on during my day job, we have some fairly crufty case-insensitive matching code. Much of it is rather specific to our use case, but I'd like to reuse some parts of bstr for it in order to speed it up, if possible.

One easy (though likely not very impactful) case is that we have a loop that [finds the next non-ascii byte](https://github.com/mozilla/application-services/blob/2eb54e48e71cf499e7e5cc8e8eda53986a8017c8/components/places/src/match_impl.rs#L183-L190), byte by byte. In practice, this always runs on ARM chips (except during local tests), so the fallback is what will be used, but the code in bstr is still substantially better than what I currently have.

That said, AFAICT isn't directly exposed yet, so I added a function for it. For consistency, it returns Option<usize>, and is named `find_non_ascii_byte` (rather than `first_non_ascii_byte`). I have no attachment to the name whatsoever, but most of the functions returning Option<usize> are prefixed with `find_`.