### PR TITLE
Valid UTF-8 chunks iterator

### DIFF
--- a/src/ext_slice.rs
+++ b/src/ext_slice.rs
@@ -25,7 +25,7 @@ use unicode::{
     SentenceIndices, Sentences, WordIndices, Words, WordsWithBreakIndices,
     WordsWithBreaks,
 };
-use utf8::{self, CharIndices, Chars, Utf8Error};
+use utf8::{self, CharIndices, Chars, Utf8Chunks, Utf8Error};
 
 /// A short-hand constructor for building a `&[u8]`.
 ///
@@ -1702,6 +1702,16 @@ pub trait ByteSlice: Sealed {
     #[inline]
     fn char_indices(&self) -> CharIndices {
         CharIndices::new(self.as_bytes())
+    }
+
+    /// Iterate over chunks of valid UTF-8.
+    ///
+    /// The iterator iterates over the chunks of valid UTF-8 separated by any
+    /// broken characters, which could be replaced by the unicode replacement
+    /// character.
+    #[inline]
+    fn utf8_chunks(&self) -> Utf8Chunks {
+        Utf8Chunks { bytes: self.as_bytes() }
     }
 
     /// Returns an iterator over the grapheme clusters in this byte string.

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -310,15 +310,16 @@ mod bstr {
 
     use bstr::BStr;
     use ext_slice::ByteSlice;
+    use utf8::Utf8Chunk;
 
     impl fmt::Display for BStr {
         #[inline]
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-            if let Ok(allutf8) = self.to_str() {
-                return fmt::Display::fmt(allutf8, f);
-            }
-            for ch in self.chars() {
-                write!(f, "{}", ch)?;
+            for Utf8Chunk { valid, broken } in self.utf8_chunks() {
+                f.write_str(valid)?;
+                if !broken.is_empty() {
+                    f.write_str("\u{FFFD}")?;
+                }
             }
             Ok(())
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -403,7 +403,7 @@ pub use unicode::{
 };
 pub use utf8::{
     decode as decode_utf8, decode_last as decode_last_utf8, CharIndices,
-    Chars, Utf8Error,
+    Chars, Utf8Chunk, Utf8Chunks, Utf8Error,
 };
 
 mod ascii;

--- a/src/utf8.rs
+++ b/src/utf8.rs
@@ -219,9 +219,9 @@ impl<'a> DoubleEndedIterator for CharIndices<'a> {
     }
 }
 
-/// An iterator over chunks of valid UTF-8 in a [`ByteSlice`].
+/// An iterator over chunks of valid UTF-8 in a [`ByteSlice`](trait.ByteSlice.html).
 ///
-/// See [`ByteSlice::utf8_chunks`].
+/// See [`utf8_chunks`](trait.ByteSlice.html#method.utf8_chunks).
 pub struct Utf8Chunks<'a> {
   pub(super) bytes: &'a [u8],
 }


### PR DESCRIPTION
This adds an api to iterate over 'mostly but not completely valid UTF-8' that's easier to use than Utf8Error, which requires the user to use unsafe code.

Inspired by `Utf8LossyChunksIter` in libcore, and mostly copied from [my `raw-string` crate](https://github.com/m-ou-se/raw-string-rs/blob/master/src/str/utf8chunks.rs).

It also makes the `Display` implementation much more efficient in the invalid UTF-8 case, as full chunks of valid UTF-8 are now written at once, only stopping to writing the replacement characters.