### PR TITLE
Exclude src/unicode/data from package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 keywords = ["string", "str", "byte", "bytes", "text"]
 license = "MIT OR Apache-2.0"
 categories = ["text-processing", "encoding"]
-exclude = ["/ci/*", "/.travis.yml", "/appveyor.yml"]
+exclude = ["/ci/*", "/.travis.yml", "/appveyor.yml", "/src/unicode/data/*"]
 
 [badges]
 travis-ci = { repository = "BurntSushi/bstr" }


### PR DESCRIPTION
According to this [comment], the unicode data in src/unicode/data is only used by tests, therefore are unnecessary in the published package. This removes 30KB from the download size.

[comment]: https://github.com/BurntSushi/bstr/issues/30#issuecomment-575351391