### PR TITLE
Add ExtSlice::escape_debug_into

### DIFF
--- a/src/impls.rs
+++ b/src/impls.rs
@@ -326,17 +326,9 @@ mod bstr {
 
     impl fmt::Debug for BStr {
         #[inline]
-        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fn fmt(&self, mut f: &mut fmt::Formatter) -> fmt::Result {
             write!(f, "\"")?;
-            for (s, e, ch) in self.char_indices() {
-                if ch == '\u{FFFD}' {
-                    for &b in self[s..e].as_bytes() {
-                        write!(f, r"\x{:X}", b)?;
-                    }
-                } else {
-                    write!(f, "{}", ch.escape_debug())?;
-                }
-            }
+            self.escape_debug_into(&mut f)?;
             write!(f, "\"")?;
             Ok(())
         }


### PR DESCRIPTION
Add a method to the `ExtSlice` trait that supports writing the `BStr`
escaped representation into a `fmt::Write`. This enables extracting the
escaped `String` into a buffer without going through `fmt::Debug`.

The written `String` does not contain the surrounding quotes present in
the `fmt::Debug` implementation.

This PR implements `fmt::Debug` on `BStr` with the new method.

Fixes GH-34.