### PR TITLE
Add a `bstr::literal!` macro for constructing a `const` BStr

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -407,6 +407,7 @@ pub use utf8::{
 };
 
 mod ascii;
+#[macro_use]
 mod bstr;
 #[cfg(feature = "std")]
 mod bstring;
@@ -452,5 +453,15 @@ mod apitests {
         assert_send::<FinderReverse>();
         assert_sync::<FinderReverse>();
         assert_unwind_safe::<FinderReverse>();
+    }
+}
+
+#[doc(hidden)]
+pub mod __private {
+    // Internal type used by the `bstr::literal!` macro. Not public.
+    #[repr(C)]
+    pub union ConstTransmuter {
+        pub bytes: &'static [u8],
+        pub bstr: &'static super::BStr,
     }
 }

--- a/tests/example.txt
+++ b/tests/example.txt
@@ -1,0 +1,1 @@
+foobar 1 2 3 abc

--- a/tests/literal.rs
+++ b/tests/literal.rs
@@ -1,0 +1,22 @@
+//! Quickly smoke test that this all compiles.
+#[macro_use]
+extern crate bstr;
+
+use bstr::{BStr, B};
+
+pub const EXAMPLE_FILE: &'static BStr =
+    literal!(include_bytes!("./example.txt"));
+pub static STATIC_ITEM: &'static BStr = literal!(b"static!");
+
+struct Foo;
+
+impl Foo {
+    pub const INHERENT: &'static BStr = literal!(b"1234");
+}
+
+#[test]
+fn test_constants() {
+    assert_eq!(EXAMPLE_FILE, literal!(b"foobar 1 2 3 abc"));
+    assert_eq!(STATIC_ITEM, literal!(b"static!"));
+    assert_eq!(Foo::INHERENT, B("1234"));
+}


### PR DESCRIPTION
I would like to use a BStr in a struct that is frequently stored in static data, but may be loaded at runtime. (It's somewhat similar to the "field in static struct" example case)

My hope is that this will improve deserialization performance (a concern here on slower machines, but I haven't measured anything) over the current `Cow<'static, [u8]>` in the case when the static data is not used. That said, there's no way to construct a `&'static BStr` usable in a constant currently.

It is unfortunate that it needs to be a macro and not a const fn, but traits in const fn aren't really coming soon, and this method works even back to 1.28.0 (it does require `repr(transparent)` for correctness).

I'm not tied to the name of the macro at all, `bstr::bstr_literal` was my initial name, but it seemed repetitive. That said, it weird that the macro is just called `literal!` when brought in via `#[macro_use]` or imported unqualified.

Anyway, this would be nice, but I'd understand if you aren't a fan -- the implementation is pretty gnarly.