### PR TITLE
ci: fix Rust toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
     - name: Install Rust
       uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: ${{ matrix.rust }}
         override: true
         profile: minimal
     - run: cargo build --verbose


### PR DESCRIPTION
Previously, we were always using 'stable' instead of the variable from
the matrix build configuration.

Fixes #49