### PR TITLE
Add missing #[inline] annotations

### DIFF
--- a/src/ext_slice.rs
+++ b/src/ext_slice.rs
@@ -125,6 +125,7 @@ pub trait ByteSlice: Sealed {
     ///
     /// println!("{:?}", b"foo\xFFbar".as_bstr());
     /// ```
+    #[inline]
     fn as_bstr(&self) -> &BStr {
         BStr::new(self.as_bytes())
     }
@@ -147,6 +148,7 @@ pub trait ByteSlice: Sealed {
     /// let mut bytes = *b"foo\xFFbar";
     /// println!("{:?}", &mut bytes.as_bstr_mut());
     /// ```
+    #[inline]
     fn as_bstr_mut(&mut self) -> &mut BStr {
         BStr::new_mut(self.as_bytes_mut())
     }
@@ -281,6 +283,7 @@ pub trait ByteSlice: Sealed {
     /// let s = unsafe { B("☃βツ").to_str_unchecked() };
     /// assert_eq!("☃βツ", s);
     /// ```
+    #[inline]
     unsafe fn to_str_unchecked(&self) -> &str {
         str::from_utf8_unchecked(self.as_bytes())
     }

--- a/src/ext_vec.rs
+++ b/src/ext_vec.rs
@@ -149,6 +149,7 @@ pub trait ByteVec: Sealed {
     /// let s = Vec::from_slice(b"abc");
     /// assert_eq!(s, B("abc"));
     /// ```
+    #[inline]
     fn from_slice<B: AsRef<[u8]>>(bytes: B) -> Vec<u8> {
         bytes.as_ref().to_vec()
     }
@@ -461,6 +462,7 @@ pub trait ByteVec: Sealed {
     /// let s = unsafe { Vec::from("☃βツ").into_string_unchecked() };
     /// assert_eq!("☃βツ", s);
     /// ```
+    #[inline]
     unsafe fn into_string_unchecked(self) -> String
     where
         Self: Sized,


### PR DESCRIPTION
Some extension functions, notably `ByteVec::into_string_unchecked` and
`ByteSlice::to_str_unchecked`, were not annotated as `#[inline]`. Since
you likely care about performance if you are using these converters, add
an `#[inline] annotation.