### PR TITLE
Use a consistent return type for `OsStr` methods

### DIFF
--- a/src/ext_vec.rs
+++ b/src/ext_vec.rs
@@ -487,13 +487,13 @@ pub trait ByteVec: Sealed {
     /// assert_eq!(os_str, OsStr::new("foo"));
     /// ```
     #[inline]
-    fn into_os_string(self) -> Result<OsString, Vec<u8>>
+    fn into_os_string(self) -> Result<OsString, FromUtf8Error>
     where
         Self: Sized,
     {
         #[cfg(unix)]
         #[inline]
-        fn imp(v: Vec<u8>) -> Result<OsString, Vec<u8>> {
+        fn imp(v: Vec<u8>) -> Result<OsString, FromUtf8Error> {
             use std::os::unix::ffi::OsStringExt;
 
             Ok(OsString::from_vec(v))
@@ -501,11 +501,8 @@ pub trait ByteVec: Sealed {
 
         #[cfg(not(unix))]
         #[inline]
-        fn imp(v: Vec<u8>) -> Result<OsString, Vec<u8>> {
-            match v.into_string() {
-                Ok(s) => Ok(OsString::from(s)),
-                Err(err) => Err(err.into_vec()),
-            }
+        fn imp(v: Vec<u8>) -> Result<OsString, FromUtf8Error> {
+            v.into_string().map(OsString::from)
         }
 
         imp(self.into_vec())
@@ -571,7 +568,7 @@ pub trait ByteVec: Sealed {
     /// assert_eq!(path.as_os_str(), "foo");
     /// ```
     #[inline]
-    fn into_path_buf(self) -> Result<PathBuf, Vec<u8>>
+    fn into_path_buf(self) -> Result<PathBuf, FromUtf8Error>
     where
         Self: Sized,
     {


### PR DESCRIPTION
This could be a good change to make before a [1.0 release](https://github.com/BurntSushi/bstr/issues/40).

It makes the return types consistent for [`into_os_string`](https://docs.rs/bstr/0.2.12/bstr/trait.ByteVec.html#method.into_os_string), [`into_path_buf`](https://docs.rs/bstr/0.2.12/bstr/trait.ByteVec.html#method.into_path_buf), and [`into_string`](https://docs.rs/bstr/0.2.12/bstr/trait.ByteVec.html#method.into_string). They already match for [`ByteSlice`](https://docs.rs/bstr/0.2.12/bstr/trait.ByteSlice.html).