### PR TITLE
Better (shorter, clearer) debug implementation

### DIFF
--- a/src/impls.rs
+++ b/src/impls.rs
@@ -329,12 +329,24 @@ mod bstr {
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
             write!(f, "\"")?;
             for (s, e, ch) in self.char_indices() {
-                if ch == '\u{FFFD}' {
-                    for &b in self[s..e].as_bytes() {
-                        write!(f, r"\x{:X}", b)?;
+                match ch {
+                    '\0' => write!(f, "\\0")?,
+                    '\u{FFFD}' => {
+                        for &b in self[s..e].as_bytes() {
+                            write!(f, r"\x{:02X}", b)?;
+                        }
                     }
-                } else {
-                    write!(f, "{}", ch.escape_debug())?;
+                    // ASCII control characters except \0, \n, \r, \t
+                    '\x01'..='\x08'
+                    | '\x0b'
+                    | '\x0c'
+                    | '\x0e'..='\x19'
+                    | '\x7f' => {
+                        write!(f, "\\x{:02x}", ch as u32)?;
+                    }
+                    '\n' | '\r' | '\t' | _ => {
+                        write!(f, "{}", ch.escape_debug())?;
+                    }
                 }
             }
             write!(f, "\"")?;
@@ -758,4 +770,13 @@ mod bstring_arbitrary {
             Box::new(self.bytes.shrink().map(BString::from))
         }
     }
+}
+
+#[test]
+fn test_debug() {
+    use crate::ByteSlice;
+    assert_eq!(
+        r#""\0\0\0 ftypisom\0\0\x02\0isomiso2avc1mp""#,
+        format!("{:?}", b"\0\0\0 ftypisom\0\0\x02\0isomiso2avc1mp".as_bstr()),
+    );
 }


### PR DESCRIPTION
Fixes #56

Note: apart from what is discussed [here](https://github.com/BurntSushi/bstr/issues/56#issuecomment-630770579) I've also included `\0` escape. In Rust this is **not an octal escape** but a special case similar to `\n` and `\t`. Given that it's quite often used in binary data, and is shorter this way, I think it justifies the special case.