### PR TITLE
Add conversions between boxed bytes and BStr

### DIFF
--- a/src/bstr.rs
+++ b/src/bstr.rs
@@ -56,6 +56,18 @@ impl BStr {
     }
 
     #[inline]
+    #[cfg(feature = "std")]
+    pub(crate) fn from_boxed_bytes(slice: Box<[u8]>) -> Box<BStr> {
+        unsafe { Box::from_raw(Box::into_raw(slice) as _) }
+    }
+
+    #[inline]
+    #[cfg(feature = "std")]
+    pub(crate) fn into_boxed_bytes(slice: Box<BStr>) -> Box<[u8]> {
+        unsafe { Box::from_raw(Box::into_raw(slice) as _) }
+    }
+
+    #[inline]
     pub(crate) fn as_bytes(&self) -> &[u8] {
         &self.bytes
     }

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -539,6 +539,22 @@ mod bstr {
         }
     }
 
+    #[cfg(feature = "std")]
+    impl From<Box<[u8]>> for Box<BStr> {
+        #[inline]
+        fn from(s: Box<[u8]>) -> Box<BStr> {
+            BStr::from_boxed_bytes(s)
+        }
+    }
+
+    #[cfg(feature = "std")]
+    impl From<Box<BStr>> for Box<[u8]> {
+        #[inline]
+        fn from(s: Box<BStr>) -> Box<[u8]> {
+            BStr::into_boxed_bytes(s)
+        }
+    }
+
     impl Eq for BStr {}
 
     impl PartialEq<BStr> for BStr {


### PR DESCRIPTION
Closes #66 

~~This _might_ require the 1.41 adjustments of local impl checking to be coherent. (Let's ask CI!) If that turns out to be the case, these impls will need to be gated behind checking for the rust version (or bump MSRV) and potentially exposed not just as the trait methods.~~ EDIT: CI says this works on MSRV 🎉