### PR TITLE
Improve example for trim_end_with().

### DIFF
--- a/src/ext_slice.rs
+++ b/src/ext_slice.rs
@@ -2225,7 +2225,7 @@ pub trait ByteSlice: Sealed {
     /// ```
     /// use bstr::{B, ByteSlice};
     ///
-    /// let s = b"123foo5bar";
+    /// let s = b"123foo5bar789";
     /// assert_eq!(s.trim_end_with(|c| c.is_numeric()), B("123foo5bar"));
     /// ```
     #[inline]


### PR DESCRIPTION
Trivial diff to make the example illustrate the function.