### PR TITLE
Make ByteVec::into_string_lossy() more efficient.

### DIFF
--- a/src/ext_vec.rs
+++ b/src/ext_vec.rs
@@ -425,15 +425,10 @@ pub trait ByteVec: Sealed {
     where
         Self: Sized,
     {
-        let v = self.as_vec();
-        if let Ok(allutf8) = v.to_str() {
-            return allutf8.to_string();
+        match self.as_vec().to_str_lossy() {
+            Cow::Borrowed(_) => unsafe { self.into_string_unchecked() },
+            Cow::Owned(s) => s,
         }
-        let mut dst = String::with_capacity(v.len());
-        for ch in v.chars() {
-            dst.push(ch);
-        }
-        dst
     }
 
     /// Unsafely convert this byte string into a `String`, without checking for

--- a/src/ext_vec.rs
+++ b/src/ext_vec.rs
@@ -426,7 +426,11 @@ pub trait ByteVec: Sealed {
         Self: Sized,
     {
         match self.as_vec().to_str_lossy() {
-            Cow::Borrowed(_) => unsafe { self.into_string_unchecked() },
+            Cow::Borrowed(_) => {
+                // SAFETY: to_str_lossy() returning a Cow::Borrowed guarantees
+                // the entire string is valid utf8.
+                unsafe { self.into_string_unchecked() }
+            }
             Cow::Owned(s) => s,
         }
     }


### PR DESCRIPTION
It now re-uses to_str_lossy() (which is more efficient than looping over v.chars() like this did), and does no  longer allocate in the case it was already valid utf-8.