### PR TITLE
Add no_std + alloc feature configuration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,8 @@ bench = false
 
 [features]
 default = ["std", "unicode"]
-std = ["memchr/std"]
+std = ["alloc", "memchr/std"]
+alloc = []
 unicode = ["lazy_static", "regex-automata"]
 serde1 = ["std", "serde1-nostd", "serde/std"]
 serde1-nostd = ["serde"]

--- a/README.md
+++ b/README.md
@@ -144,7 +144,10 @@ This crates comes with a few features that control standard library, serde
 and Unicode support.
 
 * `std` - **Enabled** by default. This provides APIs that require the standard
-  library, such as `Vec<u8>`.
+  library, such as `Vec<u8>` and `PathBuf`. Enabling this feature also enables
+  the `alloc` feature.
+* `alloc` - **Enabled** by default. This provides APIs that require allocations
+  via the `alloc` crate, such as `Vec<u8>`.
 * `unicode` - **Enabled** by default. This provides APIs that require sizable
   Unicode data compiled into the binary. This includes, but is not limited to,
   grapheme/word/sentence segmenters. When this is disabled, basic support such

--- a/src/bstr.rs
+++ b/src/bstr.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "alloc")]
+use alloc::boxed::Box;
 use core::mem;
 
 /// A wrapper for `&[u8]` that provides convenient string oriented trait impls.
@@ -56,13 +58,13 @@ impl BStr {
     }
 
     #[inline]
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     pub(crate) fn from_boxed_bytes(slice: Box<[u8]>) -> Box<BStr> {
         unsafe { Box::from_raw(Box::into_raw(slice) as _) }
     }
 
     #[inline]
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     pub(crate) fn into_boxed_bytes(slice: Box<BStr>) -> Box<[u8]> {
         unsafe { Box::from_raw(Box::into_raw(slice) as _) }
     }

--- a/src/bstring.rs
+++ b/src/bstring.rs
@@ -1,3 +1,5 @@
+use alloc::vec::Vec;
+
 use crate::bstr::BStr;
 
 /// A wrapper for `Vec<u8>` that provides convenient string oriented trait

--- a/src/byteset/mod.rs
+++ b/src/byteset/mod.rs
@@ -79,7 +79,7 @@ pub(crate) fn rfind_not(haystack: &[u8], byteset: &[u8]) -> Option<usize> {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "std"))]
 mod tests {
     quickcheck::quickcheck! {
         fn qc_byteset_forward_matches_naive(

--- a/src/byteset/scalar.rs
+++ b/src/byteset/scalar.rs
@@ -174,7 +174,7 @@ pub(crate) fn reverse_search_bytes<F: Fn(u8) -> bool>(
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "std"))]
 mod tests {
     use super::{inv_memchr, inv_memrchr};
     // search string, search byte, inv_memchr result, inv_memrchr result.

--- a/src/ext_slice.rs
+++ b/src/ext_slice.rs
@@ -1,17 +1,23 @@
-#[cfg(feature = "std")]
-use std::borrow::Cow;
+#[cfg(feature = "alloc")]
+use alloc::borrow::Cow;
+#[cfg(feature = "alloc")]
+use alloc::string::String;
+#[cfg(feature = "alloc")]
+use alloc::vec;
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
+use core::{iter, ops, ptr, slice, str};
 #[cfg(feature = "std")]
 use std::ffi::OsStr;
 #[cfg(feature = "std")]
 use std::path::Path;
 
-use core::{iter, ops, ptr, slice, str};
 use memchr::{memchr, memmem, memrchr};
 
 use crate::ascii;
 use crate::bstr::BStr;
 use crate::byteset;
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 use crate::ext_vec::ByteVec;
 #[cfg(feature = "unicode")]
 use crate::unicode::{
@@ -341,7 +347,7 @@ pub trait ByteSlice: Sealed {
     /// let bs = B(b"\x61\xF1\x80\x80\xE1\x80\xC2\x62");
     /// assert_eq!("a\u{FFFD}\u{FFFD}\u{FFFD}b", bs.to_str_lossy());
     /// ```
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     #[inline]
     fn to_str_lossy(&self) -> Cow<'_, str> {
         match utf8::validate(self.as_bytes()) {
@@ -398,7 +404,7 @@ pub trait ByteSlice: Sealed {
     /// bstring.to_str_lossy_into(&mut dest);
     /// assert_eq!("☃βツ\u{FFFD}", dest);
     /// ```
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     #[inline]
     fn to_str_lossy_into(&self, dest: &mut String) {
         let mut bytes = self.as_bytes();
@@ -584,7 +590,7 @@ pub trait ByteSlice: Sealed {
     /// assert_eq!(b"foo".repeatn(4), B("foofoofoofoo"));
     /// assert_eq!(b"foo".repeatn(0), B(""));
     /// ```
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     #[inline]
     fn repeatn(&self, n: usize) -> Vec<u8> {
         let bs = self.as_bytes();
@@ -1416,7 +1422,7 @@ pub trait ByteSlice: Sealed {
     /// let s = b"foo".replace("", "Z");
     /// assert_eq!(s, "ZfZoZoZ".as_bytes());
     /// ```
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     #[inline]
     fn replace<N: AsRef<[u8]>, R: AsRef<[u8]>>(
         &self,
@@ -1462,7 +1468,7 @@ pub trait ByteSlice: Sealed {
     /// let s = b"foo".replacen("", "Z", 2);
     /// assert_eq!(s, "ZfZoo".as_bytes());
     /// ```
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     #[inline]
     fn replacen<N: AsRef<[u8]>, R: AsRef<[u8]>>(
         &self,
@@ -1520,7 +1526,7 @@ pub trait ByteSlice: Sealed {
     /// s.replace_into("", "Z", &mut dest);
     /// assert_eq!(dest, "ZfZoZoZ".as_bytes());
     /// ```
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     #[inline]
     fn replace_into<N: AsRef<[u8]>, R: AsRef<[u8]>>(
         &self,
@@ -1584,7 +1590,7 @@ pub trait ByteSlice: Sealed {
     /// s.replacen_into("", "Z", 2, &mut dest);
     /// assert_eq!(dest, "ZfZoo".as_bytes());
     /// ```
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     #[inline]
     fn replacen_into<N: AsRef<[u8]>, R: AsRef<[u8]>>(
         &self,
@@ -2277,7 +2283,7 @@ pub trait ByteSlice: Sealed {
     /// let s = B(b"FOO\xFFBAR\xE2\x98BAZ");
     /// assert_eq!(B(b"foo\xFFbar\xE2\x98baz"), s.to_lowercase().as_bytes());
     /// ```
-    #[cfg(all(feature = "std", feature = "unicode"))]
+    #[cfg(all(feature = "alloc", feature = "unicode"))]
     #[inline]
     fn to_lowercase(&self) -> Vec<u8> {
         let mut buf = vec![];
@@ -2339,7 +2345,7 @@ pub trait ByteSlice: Sealed {
     /// s.to_lowercase_into(&mut buf);
     /// assert_eq!(B(b"foo\xFFbar\xE2\x98baz"), buf.as_bytes());
     /// ```
-    #[cfg(all(feature = "std", feature = "unicode"))]
+    #[cfg(all(feature = "alloc", feature = "unicode"))]
     #[inline]
     fn to_lowercase_into(&self, buf: &mut Vec<u8>) {
         // TODO: This is the best we can do given what std exposes I think.
@@ -2394,7 +2400,7 @@ pub trait ByteSlice: Sealed {
     /// let s = B(b"FOO\xFFBAR\xE2\x98BAZ");
     /// assert_eq!(s.to_ascii_lowercase(), B(b"foo\xFFbar\xE2\x98baz"));
     /// ```
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     #[inline]
     fn to_ascii_lowercase(&self) -> Vec<u8> {
         self.as_bytes().to_ascii_lowercase()
@@ -2480,7 +2486,7 @@ pub trait ByteSlice: Sealed {
     /// let s = B(b"foo\xFFbar\xE2\x98baz");
     /// assert_eq!(s.to_uppercase(), B(b"FOO\xFFBAR\xE2\x98BAZ"));
     /// ```
-    #[cfg(all(feature = "std", feature = "unicode"))]
+    #[cfg(all(feature = "alloc", feature = "unicode"))]
     #[inline]
     fn to_uppercase(&self) -> Vec<u8> {
         let mut buf = vec![];
@@ -2542,7 +2548,7 @@ pub trait ByteSlice: Sealed {
     /// s.to_uppercase_into(&mut buf);
     /// assert_eq!(buf, B(b"FOO\xFFBAR\xE2\x98BAZ"));
     /// ```
-    #[cfg(all(feature = "std", feature = "unicode"))]
+    #[cfg(all(feature = "alloc", feature = "unicode"))]
     #[inline]
     fn to_uppercase_into(&self, buf: &mut Vec<u8>) {
         // TODO: This is the best we can do given what std exposes I think.
@@ -2594,7 +2600,7 @@ pub trait ByteSlice: Sealed {
     /// let s = B(b"foo\xFFbar\xE2\x98baz");
     /// assert_eq!(s.to_ascii_uppercase(), B(b"FOO\xFFBAR\xE2\x98BAZ"));
     /// ```
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     #[inline]
     fn to_ascii_uppercase(&self) -> Vec<u8> {
         self.as_bytes().to_ascii_uppercase()
@@ -3591,7 +3597,7 @@ impl<'a> Iterator for LinesWithTerminator<'a> {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "std"))]
 mod tests {
     use crate::ext_slice::{ByteSlice, B};
     use crate::tests::LOSSY_TESTS;

--- a/src/ext_vec.rs
+++ b/src/ext_vec.rs
@@ -1,13 +1,17 @@
-use std::borrow::Cow;
+use alloc::borrow::Cow;
+use alloc::string::String;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::fmt;
+use core::iter;
+use core::ops;
+use core::ptr;
+#[cfg(feature = "std")]
 use std::error;
+#[cfg(feature = "std")]
 use std::ffi::{OsStr, OsString};
-use std::fmt;
-use std::iter;
-use std::ops;
+#[cfg(feature = "std")]
 use std::path::{Path, PathBuf};
-use std::ptr;
-use std::str;
-use std::vec;
 
 use crate::ext_slice::ByteSlice;
 use crate::utf8::{self, Utf8Error};
@@ -171,6 +175,7 @@ pub trait ByteVec: Sealed {
     /// assert_eq!(bs, B("foo"));
     /// ```
     #[inline]
+    #[cfg(feature = "std")]
     fn from_os_string(os_str: OsString) -> Result<Vec<u8>, OsString> {
         #[cfg(unix)]
         #[inline]
@@ -210,6 +215,7 @@ pub trait ByteVec: Sealed {
     /// assert_eq!(bs, B("foo"));
     /// ```
     #[inline]
+    #[cfg(feature = "std")]
     fn from_os_str_lossy<'a>(os_str: &'a OsStr) -> Cow<'a, [u8]> {
         #[cfg(unix)]
         #[inline]
@@ -250,6 +256,7 @@ pub trait ByteVec: Sealed {
     /// assert_eq!(bs, B("foo"));
     /// ```
     #[inline]
+    #[cfg(feature = "std")]
     fn from_path_buf(path: PathBuf) -> Result<Vec<u8>, PathBuf> {
         Vec::from_os_string(path.into_os_string()).map_err(PathBuf::from)
     }
@@ -275,6 +282,7 @@ pub trait ByteVec: Sealed {
     /// assert_eq!(bs, B("foo"));
     /// ```
     #[inline]
+    #[cfg(feature = "std")]
     fn from_path_lossy<'a>(path: &'a Path) -> Cow<'a, [u8]> {
         Vec::from_os_str_lossy(path.as_os_str())
     }
@@ -486,6 +494,7 @@ pub trait ByteVec: Sealed {
     /// assert_eq!(os_str, OsStr::new("foo"));
     /// ```
     #[inline]
+    #[cfg(feature = "std")]
     fn into_os_string(self) -> Result<OsString, Vec<u8>>
     where
         Self: Sized,
@@ -532,6 +541,7 @@ pub trait ByteVec: Sealed {
     /// assert_eq!(os_str.to_string_lossy(), "foo\u{FFFD}bar");
     /// ```
     #[inline]
+    #[cfg(feature = "std")]
     fn into_os_string_lossy(self) -> OsString
     where
         Self: Sized,
@@ -570,6 +580,7 @@ pub trait ByteVec: Sealed {
     /// assert_eq!(path.as_os_str(), "foo");
     /// ```
     #[inline]
+    #[cfg(feature = "std")]
     fn into_path_buf(self) -> Result<PathBuf, Vec<u8>>
     where
         Self: Sized,
@@ -599,6 +610,7 @@ pub trait ByteVec: Sealed {
     /// assert_eq!(path.to_string_lossy(), "foo\u{FFFD}bar");
     /// ```
     #[inline]
+    #[cfg(feature = "std")]
     fn into_path_buf_lossy(self) -> PathBuf
     where
         Self: Sized,
@@ -1029,6 +1041,7 @@ impl FromUtf8Error {
     }
 }
 
+#[cfg(feature = "std")]
 impl error::Error for FromUtf8Error {
     #[inline]
     fn description(&self) -> &str {
@@ -1043,7 +1056,7 @@ impl fmt::Display for FromUtf8Error {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "std"))]
 mod tests {
     use crate::ext_vec::ByteVec;
 

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -18,7 +18,7 @@ macro_rules! impl_partial_eq {
     };
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 macro_rules! impl_partial_eq_cow {
     ($lhs:ty, $rhs:ty) => {
         impl<'a, 'b> PartialEq<$rhs> for $lhs {
@@ -59,13 +59,16 @@ macro_rules! impl_partial_ord {
     };
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 mod bstring {
-    use std::borrow::{Borrow, Cow, ToOwned};
-    use std::cmp::Ordering;
-    use std::fmt;
-    use std::iter::FromIterator;
-    use std::ops;
+    use alloc::borrow::{Borrow, Cow, ToOwned};
+    use alloc::string::String;
+    use alloc::vec;
+    use alloc::vec::Vec;
+    use core::cmp::Ordering;
+    use core::fmt;
+    use core::iter::FromIterator;
+    use core::ops;
 
     use crate::bstr::BStr;
     use crate::bstring::BString;
@@ -301,8 +304,14 @@ mod bstring {
 }
 
 mod bstr {
-    #[cfg(feature = "std")]
-    use std::borrow::Cow;
+    #[cfg(feature = "alloc")]
+    use alloc::borrow::Cow;
+    #[cfg(feature = "alloc")]
+    use alloc::boxed::Box;
+    #[cfg(feature = "alloc")]
+    use alloc::string::String;
+    #[cfg(feature = "alloc")]
+    use alloc::vec::Vec;
 
     use core::cmp::Ordering;
     use core::fmt;
@@ -597,7 +606,7 @@ mod bstr {
         }
     }
 
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     impl<'a> From<&'a BStr> for Cow<'a, BStr> {
         #[inline]
         fn from(s: &'a BStr) -> Cow<'a, BStr> {
@@ -605,7 +614,7 @@ mod bstr {
         }
     }
 
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     impl From<Box<[u8]>> for Box<BStr> {
         #[inline]
         fn from(s: Box<[u8]>) -> Box<BStr> {
@@ -613,7 +622,7 @@ mod bstr {
         }
     }
 
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     impl From<Box<BStr>> for Box<[u8]> {
         #[inline]
         fn from(s: Box<BStr>) -> Box<[u8]> {
@@ -635,19 +644,19 @@ mod bstr {
     impl_partial_eq!(BStr, str);
     impl_partial_eq!(BStr, &'a str);
 
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     impl_partial_eq!(BStr, Vec<u8>);
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     impl_partial_eq!(&'a BStr, Vec<u8>);
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     impl_partial_eq!(BStr, String);
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     impl_partial_eq!(&'a BStr, String);
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     impl_partial_eq_cow!(&'a BStr, Cow<'a, BStr>);
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     impl_partial_eq_cow!(&'a BStr, Cow<'a, str>);
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     impl_partial_eq_cow!(&'a BStr, Cow<'a, [u8]>);
 
     impl PartialOrd for BStr {
@@ -669,13 +678,13 @@ mod bstr {
     impl_partial_ord!(BStr, str);
     impl_partial_ord!(BStr, &'a str);
 
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     impl_partial_ord!(BStr, Vec<u8>);
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     impl_partial_ord!(&'a BStr, Vec<u8>);
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     impl_partial_ord!(BStr, String);
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     impl_partial_ord!(&'a BStr, String);
 }
 
@@ -739,8 +748,10 @@ mod bstr_serde {
 
 #[cfg(feature = "serde1")]
 mod bstring_serde {
-    use std::cmp;
-    use std::fmt;
+    use alloc::string::String;
+    use alloc::vec::Vec;
+    use core::cmp;
+    use core::fmt;
 
     use serde::{
         de::Error, de::SeqAccess, de::Visitor, Deserialize, Deserializer,
@@ -825,7 +836,7 @@ mod bstring_serde {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "std"))]
 mod display {
     use crate::bstring::BString;
     use crate::ByteSlice;
@@ -934,7 +945,7 @@ mod display {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "std"))]
 mod bstring_arbitrary {
     use crate::bstring::BString;
 
@@ -952,6 +963,7 @@ mod bstring_arbitrary {
 }
 
 #[test]
+#[cfg(feature = "std")]
 fn test_debug() {
     use crate::{ByteSlice, B};
 
@@ -973,9 +985,11 @@ fn test_debug() {
 
 // See: https://github.com/BurntSushi/bstr/issues/82
 #[test]
+#[cfg(feature = "std")]
 fn test_cows_regression() {
-    use crate::ByteSlice;
     use std::borrow::Cow;
+
+    use crate::ByteSlice;
 
     let c1 = Cow::from(b"hello bstr".as_bstr());
     let c2 = b"goodbye bstr".as_bstr();

--- a/src/io.rs
+++ b/src/io.rs
@@ -7,6 +7,8 @@ facilities for conveniently and efficiently working with lines as byte strings.
 More APIs may be added in the future.
 */
 
+use alloc::vec;
+use alloc::vec::Vec;
 use std::io;
 
 use crate::ext_slice::ByteSlice;
@@ -438,7 +440,7 @@ fn trim_record_slice(mut record: &[u8], terminator: u8) -> &[u8] {
     record
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "std"))]
 mod tests {
     use super::BufReadExt;
     use crate::bstring::BString;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -367,17 +367,20 @@ to write correct code for Unix, at the cost of getting a corner case wrong on
 Windows.
 */
 
-#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(not(any(feature = "std", test)), no_std)]
+
+#[cfg(feature = "alloc")]
+extern crate alloc;
 
 pub use crate::bstr::BStr;
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 pub use crate::bstring::BString;
 pub use crate::ext_slice::{
     ByteSlice, Bytes, Fields, FieldsWith, Find, FindReverse, Finder,
     FinderReverse, Lines, LinesWithTerminator, Split, SplitN, SplitNReverse,
     SplitReverse, B,
 };
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 pub use crate::ext_vec::{concat, join, ByteVec, DrainBytes, FromUtf8Error};
 #[cfg(feature = "unicode")]
 pub use crate::unicode::{
@@ -391,22 +394,22 @@ pub use crate::utf8::{
 
 mod ascii;
 mod bstr;
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 mod bstring;
 mod byteset;
 mod ext_slice;
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 mod ext_vec;
 mod impls;
 #[cfg(feature = "std")]
 pub mod io;
-#[cfg(test)]
+#[cfg(all(test, feature = "std"))]
 mod tests;
 #[cfg(feature = "unicode")]
 mod unicode;
 mod utf8;
 
-#[cfg(test)]
+#[cfg(all(test, feature = "std"))]
 mod apitests {
     use crate::bstr::BStr;
     use crate::bstring::BString;

--- a/src/unicode/grapheme.rs
+++ b/src/unicode/grapheme.rs
@@ -257,7 +257,7 @@ fn adjust_rev_for_regional_indicator(mut bs: &[u8], i: usize) -> usize {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "std"))]
 mod tests {
     use ucd_parse::GraphemeClusterBreakTest;
 

--- a/src/unicode/sentence.rs
+++ b/src/unicode/sentence.rs
@@ -156,7 +156,7 @@ fn decode_sentence(bs: &[u8]) -> (&str, usize) {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "std"))]
 mod tests {
     use ucd_parse::SentenceBreakTest;
 

--- a/src/unicode/word.rs
+++ b/src/unicode/word.rs
@@ -316,7 +316,7 @@ fn decode_word(bs: &[u8]) -> (&str, usize) {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "std"))]
 mod tests {
     use ucd_parse::WordBreakTest;
 

--- a/src/utf8.rs
+++ b/src/utf8.rs
@@ -854,7 +854,7 @@ fn is_leading_or_invalid_utf8_byte(b: u8) -> bool {
     (b & 0b1100_0000) != 0b1000_0000
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "std"))]
 mod tests {
     use std::char;
 


### PR DESCRIPTION
This commit enables `bstr` to build and test without a dependency on
`std`. This change was mostly munging `use` statements to prefer `core`
and `alloc` and changing around `cfg`s.

This change also enables `bstr` to successfully test in `no_std` and
`alloc` configurations. The following succeed where they did not even
compile before:

```
cargo test --no-default-features --lib
cargo test --no-default-features --lib --features alloc
```

Fixes #79.