### PR TITLE
Fix capacity overflow on `ByteSlice::repeatn` and improve perf

### DIFF
--- a/src/ext_slice.rs
+++ b/src/ext_slice.rs
@@ -587,12 +587,7 @@ pub trait ByteSlice: Sealed {
     #[cfg(feature = "std")]
     #[inline]
     fn repeatn(&self, n: usize) -> Vec<u8> {
-        let bs = self.as_bytes();
-        let mut dst = vec![0; bs.len() * n];
-        for i in 0..n {
-            dst[i * bs.len()..(i + 1) * bs.len()].copy_from_slice(bs);
-        }
-        dst
+        self.as_bytes().repeat(n)
     }
 
     /// Returns true if and only if this byte string contains the given needle.


### PR DESCRIPTION
Implement `ByteSlice::repeatn` with `<[u8]>::repeat`.

`repeat` on slices is stable since Rust 1.40.0 and does an exponential
`ptr::copy_nonoverlapping`. The implementation in `alloc` also correctly
handles the capacity overflow when `len * n` is more than `usize::MAX`.