### PR TITLE
api: impl Clone and Debug for Lines and LinesWithTerminator

### DIFF
--- a/src/ext_slice.rs
+++ b/src/ext_slice.rs
@@ -3521,6 +3521,7 @@ impl<'a> Iterator for SplitNReverse<'a> {
 /// `\n`.
 ///
 /// `'a` is the lifetime of the byte string being iterated over.
+#[derive(Clone, Debug)]
 pub struct Lines<'a> {
     it: LinesWithTerminator<'a>,
 }
@@ -3560,6 +3561,7 @@ impl<'a> Iterator for Lines<'a> {
 /// the original byte string.
 ///
 /// `'a` is the lifetime of the byte string being iterated over.
+#[derive(Clone, Debug)]
 pub struct LinesWithTerminator<'a> {
     bytes: &'a [u8],
 }


### PR DESCRIPTION
`Debug` for consistency with other structs in `bstr`. `Clone` to avoid
having to re-traverse bytes when you need another iterator at a certain
location.