### PR TITLE
api: add `Lines::to_bytes()` and `LinesWithTerminator::to_bytes()`

### DIFF
--- a/src/ext_slice.rs
+++ b/src/ext_slice.rs
@@ -3529,6 +3529,27 @@ impl<'a> Lines<'a> {
     fn new(bytes: &'a [u8]) -> Lines<'a> {
         Lines { it: LinesWithTerminator::new(bytes) }
     }
+
+    /// Return a copy of the rest of the buffer without affecting the iterator itself.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// use bstr::{B, ByteSlice};
+    ///
+    /// let s = b"\
+    /// foo
+    /// bar\r
+    /// baz";
+    /// let mut lines = s.lines();
+    /// assert_eq!(lines.next(), Some(B("foo")));
+    /// assert_eq!(lines.to_bytes(), B("bar\r\nbaz"));
+    /// ```
+    pub fn to_bytes(&self) -> &'a [u8] {
+        self.it.bytes
+    }
 }
 
 impl<'a> Iterator for Lines<'a> {
@@ -3567,6 +3588,27 @@ pub struct LinesWithTerminator<'a> {
 impl<'a> LinesWithTerminator<'a> {
     fn new(bytes: &'a [u8]) -> LinesWithTerminator<'a> {
         LinesWithTerminator { bytes }
+    }
+
+    /// Return a copy of the rest of the buffer without affecting the iterator itself.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// use bstr::{B, ByteSlice};
+    ///
+    /// let s = b"\
+    /// foo
+    /// bar\r
+    /// baz";
+    /// let mut lines = s.lines_with_terminator();
+    /// assert_eq!(lines.next(), Some(B("foo\n")));
+    /// assert_eq!(lines.to_bytes(), B("bar\r\nbaz"));
+    /// ```
+    pub fn to_bytes(&self) -> &'a [u8] {
+        self.bytes
     }
 }
 


### PR DESCRIPTION
Allowing access to the buffer itself may make some use cases simpler
when access to the original buffer after consuming a few lines is
preferrable.

Without it, one would have to find a way to count the consumed bytes
themselves.

The addition of `to_bytes()` definitely counts as quality of life
improvement for some.

---- 

That said, this PR was originally motivated by 'getting off the wrong foot' which made me keep the original instead of the iterator itself, making a [workaround necessary](https://github.com/Byron/gitoxide/pull/359/commits/6a37eee5292bacdaca8c97608e900872128ae9bf#diff-44359de661c0ad576ab2f680daacc8cc6098d89595e871f6cca27cf53b3a6f98R58) to accommodate this. I would have loved to have `to_bytes()` in this moment. Right after creating this PR, I figured that [using the iterator directly](https://github.com/Byron/gitoxide/pull/359/commits/9a9115f8db0a84818600f125b1185d1773f10d39) is much easier.

Having something like `to_bytes()` makes the iterators more versatile I think, but also supports getting off the wrong foot like I did. However, optimist that I am, I'd think that the more versatility ultimately is preferable over restrictions and someone will have legitimate use for it.