### PR TITLE
Fix (stacked-borrows-)UB found by Miri

### DIFF
--- a/src/byteset/scalar.rs
+++ b/src/byteset/scalar.rs
@@ -67,7 +67,7 @@ pub fn inv_memrchr(n1: u8, haystack: &[u8]) -> Option<usize> {
     let loop_size = cmp::min(LOOP_SIZE, haystack.len());
     let align = USIZE_BYTES - 1;
     let start_ptr = haystack.as_ptr();
-    let end_ptr = haystack[haystack.len()..].as_ptr();
+    let end_ptr = unsafe { haystack.as_ptr().add(haystack.len()) };
     let mut ptr = end_ptr;
 
     unsafe {

--- a/src/ext_slice.rs
+++ b/src/ext_slice.rs
@@ -3063,11 +3063,8 @@ pub trait ByteSlice: Sealed {
         // Finally, we are only dealing with u8 data, which is Copy, which
         // means we can copy without worrying about ownership/destructors.
         unsafe {
-            ptr::copy(
-                self.as_bytes().get_unchecked(src_start),
-                self.as_bytes_mut().get_unchecked_mut(dest),
-                count,
-            );
+            let ptr = self.as_bytes_mut().as_mut_ptr();
+            ptr::copy(ptr.add(src_start), ptr.add(dest), count);
         }
     }
 }


### PR DESCRIPTION
The `ptr::copy` is a common footgun in the current formulation of Stacked Borrows: https://github.com/rust-lang/unsafe-code-guidelines/issues/133 Ralf thinks we can be rid of it, but until then it would be nice if MIri passes.

The issue with `end_ptr` is that originally this code turns a slice into a pointer, but then tries to walk the pointer outside of the slice. You can't do that in Stacked Borrows, pointers derived from references can only be used to access the referent, not the whole allocation.

(also it might be cool to have Miri in CI, but I think you know better than I what to sculpt with the test cases that run for too long in the interpreter)