### PR TITLE
Fix `@rev` parameter of dtolnay/rust-toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v3
     - name: Install Rust
-      uses: dtolnay/rust-toolchain@v1
+      uses: dtolnay/rust-toolchain@master
       with:
         toolchain: ${{ matrix.rust }}
     - run: cargo build --verbose
@@ -92,9 +92,8 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v3
     - name: Install Rust
-      uses: dtolnay/rust-toolchain@v1
+      uses: dtolnay/rust-toolchain@stable
       with:
-        toolchain: stable
         components: rustfmt
     - name: Check formatting
       run: |


### PR DESCRIPTION
dtolnay/rust-toolchain parses the desired toolchain version from the `@rev` parameter. If one wants to use the explicit `toolchain` input, `@master` should be specified.