### PR TITLE
rollup + hopefully final prep before 1.0 release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v3
     - name: Install Rust
-      uses: dtolnay/rust-toolchain@v1
+      uses: dtolnay/rust-toolchain@master
       with:
         toolchain: ${{ matrix.rust }}
     - run: cargo build --verbose
@@ -92,7 +92,7 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v3
     - name: Install Rust
-      uses: dtolnay/rust-toolchain@v1
+      uses: dtolnay/rust-toolchain@master
       with:
         toolchain: stable
         components: rustfmt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         include:
         - build: pinned
           os: ubuntu-18.04
-          rust: 1.48.0
+          rust: 1.60.0
         - build: stable
           os: ubuntu-18.04
           rust: stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,13 +50,13 @@ jobs:
     # We run a few other builds, but only on one instance to avoid doing
     # more work than we need to.
     - if: matrix.build == 'stable'
-      run: cargo build --verbose --features serde1-std
+      run: cargo build --verbose --features serde
     - if: matrix.build == 'stable'
       run: cargo build --verbose --no-default-features
     - if: matrix.build == 'stable'
-      run: cargo build --verbose --no-default-features --features serde1-alloc
+      run: cargo build --verbose --no-default-features --features serde,alloc
     - if: matrix.build == 'stable'
-      run: cargo build --verbose --no-default-features --features serde1-core
+      run: cargo build --verbose --no-default-features --features serde
     - if: matrix.build == 'stable'
       run: cargo build --verbose --no-default-features --features alloc
     # Our dev dependencies evolve more rapidly than we'd like, so only run
@@ -67,19 +67,17 @@ jobs:
     # combinations, but just on 'stable' to avoid doing more work that we have
     # to.
     - if: matrix.build == 'stable'
-      run: cargo test --verbose --features serde1-std
+      run: cargo test --verbose --features serde
     - if: matrix.build == 'stable'
       run: cargo test --verbose --no-default-features
     - if: matrix.build == 'stable'
-      run: cargo test --verbose --no-default-features --features serde1-alloc
+      run: cargo test --verbose --no-default-features --features serde,alloc
     - if: matrix.build == 'stable'
-      run: cargo test --verbose --no-default-features --features serde1-core
+      run: cargo test --verbose --no-default-features --features serde
     - if: matrix.build == 'stable'
       run: cargo test --verbose --no-default-features --features alloc
     - if: matrix.build == 'stable'
       run: cargo test --verbose --no-default-features --features alloc,unicode
-    - if: matrix.build == 'stable'
-      run: cargo test --verbose --no-default-features --features unicode,serde1-alloc
     - name: Run benchmarks as tests
       if: matrix.build == 'stable'
       working-directory: ./bench

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,12 +22,10 @@ bench = false
 
 [features]
 default = ["std", "unicode"]
-std = ["alloc", "memchr/std"]
-alloc = []
-unicode = ["lazy_static", "regex-automata"]
-serde1-std = ["std", "serde1-alloc", "serde/std"]
-serde1-alloc = ["alloc", "serde1-core", "serde/alloc"]
-serde1-core = ["serde"]
+std = ["alloc", "memchr/std", "serde?/std"]
+alloc = ["serde?/alloc"]
+unicode = ["dep:lazy_static", "dep:regex-automata"]
+serde = ["dep:serde"]
 
 [dependencies]
 memchr = { version = "2.4.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,8 @@ keywords = ["string", "str", "byte", "bytes", "text"]
 license = "MIT OR Apache-2.0"
 categories = ["text-processing", "encoding"]
 exclude = ["/.github"]
-edition = "2018"
+edition = "2021"
+resolver = "2"
 
 [workspace]
 members = ["bench"]

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ and Unicode support.
 
 ### Minimum Rust version policy
 
-This crate's minimum supported `rustc` version (MSRV) is `1.48.0`.
+This crate's minimum supported `rustc` version (MSRV) is `1.60.0`.
 
 In general, this crate will be conservative with respect to the minimum
 supported version of Rust. MSRV may be bumped in minor version releases.

--- a/README.md
+++ b/README.md
@@ -144,16 +144,8 @@ and Unicode support.
   Unicode data compiled into the binary. This includes, but is not limited to,
   grapheme/word/sentence segmenters. When this is disabled, basic support such
   as UTF-8 decoding is still included.
-* `serde1-std` - **Disabled** by default. Enables implementations of serde
-  traits for the `BStr` and `BString` types. This also enables the `std` and
-  `serde/std` features.
-* `serde1-alloc` - **Disabled** by default. Enables implementations of serde
-  traits for the `BStr` and `BString` types, but without enabling `serde/std`.
-  Instead, `serde/alloc` is enabled. This also enables the `alloc` feature.
-* `serde1-core` - **Disabled** by default. Enables implementations of serde
-  traits for the `BStr` type only, intended for use without `std` or `alloc`.
-  Generally, you want at most one of `serde1-std`, `serde1-alloc` or
-  `serde1-core`, but not more than one.
+* `serde` - Enables implementations of serde traits for `BStr`, and also
+  `BString` when `alloc` is enabled.
 
 
 ### Minimum Rust version policy

--- a/src/byteset/mod.rs
+++ b/src/byteset/mod.rs
@@ -80,7 +80,7 @@ pub(crate) fn rfind_not(haystack: &[u8], byteset: &[u8]) -> Option<usize> {
     }
 }
 
-#[cfg(all(test, feature = "std"))]
+#[cfg(all(test, feature = "std", not(miri)))]
 mod tests {
     quickcheck::quickcheck! {
         fn qc_byteset_forward_matches_naive(

--- a/src/byteset/scalar.rs
+++ b/src/byteset/scalar.rs
@@ -82,7 +82,7 @@ pub fn inv_memrchr(n1: u8, haystack: &[u8]) -> Option<usize> {
             return reverse_search(start_ptr, end_ptr, ptr, confirm);
         }
 
-        ptr = (end_ptr as usize & !align) as *const u8;
+        ptr = ptr.sub(end_ptr as usize & align);
         debug_assert!(start_ptr <= ptr && ptr <= end_ptr);
         while loop_size == LOOP_SIZE && ptr >= start_ptr.add(loop_size) {
             debug_assert_eq!(0, (ptr as usize) % USIZE_BYTES);

--- a/src/byteset/scalar.rs
+++ b/src/byteset/scalar.rs
@@ -28,10 +28,11 @@ pub fn inv_memchr(n1: u8, haystack: &[u8]) -> Option<usize> {
     let loop_size = cmp::min(LOOP_SIZE, haystack.len());
     let align = USIZE_BYTES - 1;
     let start_ptr = haystack.as_ptr();
-    let end_ptr = haystack[haystack.len()..].as_ptr();
-    let mut ptr = start_ptr;
 
     unsafe {
+        let end_ptr = haystack.as_ptr().add(haystack.len());
+        let mut ptr = start_ptr;
+
         if haystack.len() < USIZE_BYTES {
             return forward_search(start_ptr, end_ptr, ptr, confirm);
         }
@@ -67,10 +68,11 @@ pub fn inv_memrchr(n1: u8, haystack: &[u8]) -> Option<usize> {
     let loop_size = cmp::min(LOOP_SIZE, haystack.len());
     let align = USIZE_BYTES - 1;
     let start_ptr = haystack.as_ptr();
-    let end_ptr = haystack[haystack.len()..].as_ptr();
-    let mut ptr = end_ptr;
 
     unsafe {
+        let end_ptr = haystack.as_ptr().add(haystack.len());
+        let mut ptr = end_ptr;
+
         if haystack.len() < USIZE_BYTES {
             return reverse_search(start_ptr, end_ptr, ptr, confirm);
         }

--- a/src/ext_slice.rs
+++ b/src/ext_slice.rs
@@ -153,11 +153,12 @@ pub trait ByteSlice: Sealed {
 
     /// Create an immutable byte string from an OS string slice.
     ///
-    /// On Unix, this always succeeds and is zero cost. On non-Unix systems,
-    /// this returns `None` if the given OS string is not valid UTF-8. (For
-    /// example, on Windows, file paths are allowed to be a sequence of
-    /// arbitrary 16-bit integers. Not all such sequences can be transcoded to
-    /// valid UTF-8.)
+    /// When the underlying bytes of OS strings are accessible, then this
+    /// always succeeds and is zero cost. Otherwise, this returns `None` if the
+    /// given OS string is not valid UTF-8. (For example, when the underlying
+    /// bytes are inaccessible on Windows, file paths are allowed to be a
+    /// sequence of arbitrary 16-bit integers. Not all such sequences can be
+    /// transcoded to valid UTF-8.)
     ///
     /// # Examples
     ///
@@ -194,10 +195,12 @@ pub trait ByteSlice: Sealed {
 
     /// Create an immutable byte string from a file path.
     ///
-    /// On Unix, this always succeeds and is zero cost. On non-Unix systems,
-    /// this returns `None` if the given path is not valid UTF-8. (For example,
-    /// on Windows, file paths are allowed to be a sequence of arbitrary 16-bit
-    /// integers. Not all such sequences can be transcoded to valid UTF-8.)
+    /// When the underlying bytes of paths are accessible, then this always
+    /// succeeds and is zero cost. Otherwise, this returns `None` if the given
+    /// path is not valid UTF-8. (For example, when the underlying bytes are
+    /// inaccessible on Windows, file paths are allowed to be a sequence of
+    /// arbitrary 16-bit integers. Not all such sequences can be transcoded to
+    /// valid UTF-8.)
     ///
     /// # Examples
     ///
@@ -434,12 +437,15 @@ pub trait ByteSlice: Sealed {
 
     /// Create an OS string slice from this byte string.
     ///
-    /// On Unix, this always succeeds and is zero cost. On non-Unix systems,
-    /// this returns a UTF-8 decoding error if this byte string is not valid
-    /// UTF-8. (For example, on Windows, file paths are allowed to be a
-    /// sequence of arbitrary 16-bit integers. There is no obvious mapping from
-    /// an arbitrary sequence of 8-bit integers to an arbitrary sequence of
-    /// 16-bit integers.)
+    /// When OS strings can be constructed from arbitrary byte sequences, this
+    /// always succeeds and is zero cost. Otherwise, this returns a UTF-8
+    /// decoding error if this byte string is not valid UTF-8. (For example,
+    /// assuming the representation of `OsStr` is opaque on Windows, file paths
+    /// are allowed to be a sequence of arbitrary 16-bit integers. There is
+    /// no obvious mapping from an arbitrary sequence of 8-bit integers to an
+    /// arbitrary sequence of 16-bit integers. If the representation of `OsStr`
+    /// is even opened up, then this will convert any sequence of bytes to an
+    /// `OsStr` without cost.)
     ///
     /// # Examples
     ///
@@ -473,13 +479,13 @@ pub trait ByteSlice: Sealed {
 
     /// Lossily create an OS string slice from this byte string.
     ///
-    /// On Unix, this always succeeds and is zero cost. On non-Unix systems,
-    /// this will perform a UTF-8 check and lossily convert this byte string
-    /// into valid UTF-8 using the Unicode replacement codepoint.
+    /// When OS strings can be constructed from arbitrary byte sequences, this
+    /// is zero cost and always returns a slice. Otherwise, this will perform a
+    /// UTF-8 check and lossily convert this byte string into valid UTF-8 using
+    /// the Unicode replacement codepoint.
     ///
-    /// Note that this can prevent the correct roundtripping of file paths on
-    /// non-Unix systems such as Windows, where file paths are an arbitrary
-    /// sequence of 16-bit integers.
+    /// Note that this can prevent the correct roundtripping of file paths when
+    /// the representation of `OsStr` is opaque.
     ///
     /// # Examples
     ///
@@ -518,12 +524,15 @@ pub trait ByteSlice: Sealed {
 
     /// Create a path slice from this byte string.
     ///
-    /// On Unix, this always succeeds and is zero cost. On non-Unix systems,
-    /// this returns a UTF-8 decoding error if this byte string is not valid
-    /// UTF-8. (For example, on Windows, file paths are allowed to be a
-    /// sequence of arbitrary 16-bit integers. There is no obvious mapping from
-    /// an arbitrary sequence of 8-bit integers to an arbitrary sequence of
-    /// 16-bit integers.)
+    /// When paths can be constructed from arbitrary byte sequences, this
+    /// always succeeds and is zero cost. Otherwise, this returns a UTF-8
+    /// decoding error if this byte string is not valid UTF-8. (For example,
+    /// assuming the representation of `Path` is opaque on Windows, file paths
+    /// are allowed to be a sequence of arbitrary 16-bit integers. There is
+    /// no obvious mapping from an arbitrary sequence of 8-bit integers to an
+    /// arbitrary sequence of 16-bit integers. If the representation of `Path`
+    /// is even opened up, then this will convert any sequence of bytes to an
+    /// `Path` without cost.)
     ///
     /// # Examples
     ///
@@ -543,13 +552,13 @@ pub trait ByteSlice: Sealed {
 
     /// Lossily create a path slice from this byte string.
     ///
-    /// On Unix, this always succeeds and is zero cost. On non-Unix systems,
-    /// this will perform a UTF-8 check and lossily convert this byte string
-    /// into valid UTF-8 using the Unicode replacement codepoint.
+    /// When paths can be constructed from arbitrary byte sequences, this is
+    /// zero cost and always returns a slice. Otherwise, this will perform a
+    /// UTF-8 check and lossily convert this byte string into valid UTF-8 using
+    /// the Unicode replacement codepoint.
     ///
-    /// Note that this can prevent the correct roundtripping of file paths on
-    /// non-Unix systems such as Windows, where file paths are an arbitrary
-    /// sequence of 16-bit integers.
+    /// Note that this can prevent the correct roundtripping of file paths when
+    /// the representation of `Path` is opaque.
     ///
     /// # Examples
     ///

--- a/src/ext_slice.rs
+++ b/src/ext_slice.rs
@@ -3063,11 +3063,8 @@ pub trait ByteSlice: Sealed {
         // Finally, we are only dealing with u8 data, which is Copy, which
         // means we can copy without worrying about ownership/destructors.
         unsafe {
-            ptr::copy(
-                self.as_bytes().get_unchecked(src_start),
-                self.as_bytes_mut().get_unchecked_mut(dest),
-                count,
-            );
+            let ptr = self.as_bytes_mut().as_mut_ptr();
+            ptr::copy(ptr.add(src_start), ptr.add(dest), count);
         }
     }
 }

--- a/src/ext_vec.rs
+++ b/src/ext_vec.rs
@@ -159,8 +159,9 @@ pub trait ByteVec: Sealed {
 
     /// Create a new byte string from an owned OS string.
     ///
-    /// On Unix, this always succeeds and is zero cost. On non-Unix systems,
-    /// this returns the original OS string if it is not valid UTF-8.
+    /// When the underlying bytes of OS strings are accessible, then this
+    /// always succeeds and is zero cost. Otherwise, this returns the given
+    /// `OsString` if it is not valid UTF-8.
     ///
     /// # Examples
     ///
@@ -197,10 +198,11 @@ pub trait ByteVec: Sealed {
 
     /// Lossily create a new byte string from an OS string slice.
     ///
-    /// On Unix, this always succeeds, is zero cost and always returns a slice.
-    /// On non-Unix systems, this does a UTF-8 check. If the given OS string
-    /// slice is not valid UTF-8, then it is lossily decoded into valid UTF-8
-    /// (with invalid bytes replaced by the Unicode replacement codepoint).
+    /// When the underlying bytes of OS strings are accessible, then this is
+    /// zero cost and always returns a slice. Otherwise, a UTF-8 check is
+    /// performed and if the given OS string is not valid UTF-8, then it is
+    /// lossily decoded into valid UTF-8 (with invalid bytes replaced by the
+    /// Unicode replacement codepoint).
     ///
     /// # Examples
     ///
@@ -240,8 +242,9 @@ pub trait ByteVec: Sealed {
 
     /// Create a new byte string from an owned file path.
     ///
-    /// On Unix, this always succeeds and is zero cost. On non-Unix systems,
-    /// this returns the original path if it is not valid UTF-8.
+    /// When the underlying bytes of paths are accessible, then this always
+    /// succeeds and is zero cost. Otherwise, this returns the given `PathBuf`
+    /// if it is not valid UTF-8.
     ///
     /// # Examples
     ///
@@ -264,10 +267,11 @@ pub trait ByteVec: Sealed {
 
     /// Lossily create a new byte string from a file path.
     ///
-    /// On Unix, this always succeeds, is zero cost and always returns a slice.
-    /// On non-Unix systems, this does a UTF-8 check. If the given path is not
-    /// valid UTF-8, then it is lossily decoded into valid UTF-8 (with invalid
-    /// bytes replaced by the Unicode replacement codepoint).
+    /// When the underlying bytes of paths are accessible, then this is
+    /// zero cost and always returns a slice. Otherwise, a UTF-8 check is
+    /// performed and if the given path is not valid UTF-8, then it is lossily
+    /// decoded into valid UTF-8 (with invalid bytes replaced by the Unicode
+    /// replacement codepoint).
     ///
     /// # Examples
     ///
@@ -476,8 +480,9 @@ pub trait ByteVec: Sealed {
 
     /// Converts this byte string into an OS string, in place.
     ///
-    /// On Unix, this always succeeds and is zero cost. On non-Unix systems,
-    /// this returns the original byte string if it is not valid UTF-8.
+    /// When OS strings can be constructed from arbitrary byte sequences, this
+    /// always succeeds and is zero cost. Otherwise, if this byte string is not
+    /// valid UTF-8, then an error (with the original byte string) is returned.
     ///
     /// # Examples
     ///
@@ -517,13 +522,13 @@ pub trait ByteVec: Sealed {
 
     /// Lossily converts this byte string into an OS string, in place.
     ///
-    /// On Unix, this always succeeds and is zero cost. On non-Unix systems,
-    /// this will perform a UTF-8 check and lossily convert this byte string
-    /// into valid UTF-8 using the Unicode replacement codepoint.
+    /// When OS strings can be constructed from arbitrary byte sequences, this
+    /// is zero cost and always returns a slice. Otherwise, this will perform a
+    /// UTF-8 check and lossily convert this byte string into valid UTF-8 using
+    /// the Unicode replacement codepoint.
     ///
-    /// Note that this can prevent the correct roundtripping of file paths on
-    /// non-Unix systems such as Windows, where file paths are an arbitrary
-    /// sequence of 16-bit integers.
+    /// Note that this can prevent the correct roundtripping of file paths when
+    /// the representation of `OsString` is opaque.
     ///
     /// # Examples
     ///
@@ -561,8 +566,9 @@ pub trait ByteVec: Sealed {
 
     /// Converts this byte string into an owned file path, in place.
     ///
-    /// On Unix, this always succeeds and is zero cost. On non-Unix systems,
-    /// this returns the original byte string if it is not valid UTF-8.
+    /// When paths can be constructed from arbitrary byte sequences, this
+    /// always succeeds and is zero cost. Otherwise, if this byte string is not
+    /// valid UTF-8, then an error (with the original byte string) is returned.
     ///
     /// # Examples
     ///
@@ -586,13 +592,13 @@ pub trait ByteVec: Sealed {
 
     /// Lossily converts this byte string into an owned file path, in place.
     ///
-    /// On Unix, this always succeeds and is zero cost. On non-Unix systems,
-    /// this will perform a UTF-8 check and lossily convert this byte string
-    /// into valid UTF-8 using the Unicode replacement codepoint.
+    /// When paths can be constructed from arbitrary byte sequences, this is
+    /// zero cost and always returns a slice. Otherwise, this will perform a
+    /// UTF-8 check and lossily convert this byte string into valid UTF-8 using
+    /// the Unicode replacement codepoint.
     ///
-    /// Note that this can prevent the correct roundtripping of file paths on
-    /// non-Unix systems such as Windows, where file paths are an arbitrary
-    /// sequence of 16-bit integers.
+    /// Note that this can prevent the correct roundtripping of file paths when
+    /// the representation of `PathBuf` is opaque.
     ///
     /// # Examples
     ///

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -874,7 +874,9 @@ mod bstring_serde {
 
 #[cfg(all(test, feature = "std"))]
 mod display {
-    use crate::{bstring::BString, ByteSlice};
+    #[cfg(not(miri))]
+    use crate::bstring::BString;
+    use crate::ByteSlice;
 
     #[test]
     fn clean() {
@@ -972,6 +974,7 @@ mod display {
         );
     }
 
+    #[cfg(not(miri))]
     quickcheck::quickcheck! {
         fn total_length(bstr: BString) -> bool {
             let size = bstr.chars().count();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -322,7 +322,8 @@ they can do:
    by accessing their underlying 16-bit integer representation. Unfortunately,
    this isn't zero cost (it introduces a second WTF-8 decoding step) and it's
    not clear this is a good thing to do, since WTF-8 should ideally remain an
-   internal implementation detail.
+   internal implementation detail. This is roughly the approach taken by the
+   [`os_str_bytes`](https://crates.io/crates/os_str_bytes) crate.
 2. One could instead declare that they will not handle paths on Windows that
    are not valid UTF-16, and return an error when one is encountered.
 3. Like (2), but instead of returning an error, lossily decode the file path

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -370,6 +370,23 @@ UTF-8, and thus contain latent bugs on Unix where paths with invalid UTF-8 are
 not terribly uncommon. If you instead use byte strings, then you're guaranteed
 to write correct code for Unix, at the cost of getting a corner case wrong on
 Windows.
+
+# Cargo features
+
+This crates comes with a few features that control standard library, serde
+and Unicode support.
+
+* `std` - **Enabled** by default. This provides APIs that require the standard
+  library, such as `Vec<u8>` and `PathBuf`. Enabling this feature also enables
+  the `alloc` feature and any other relevant `std` features for dependencies.
+* `alloc` - **Enabled** by default. This provides APIs that require allocations
+  via the `alloc` crate, such as `Vec<u8>`.
+* `unicode` - **Enabled** by default. This provides APIs that require sizable
+  Unicode data compiled into the binary. This includes, but is not limited to,
+  grapheme/word/sentence segmenters. When this is disabled, basic support such
+  as UTF-8 decoding is still included.
+* `serde` - Enables implementations of serde traits for `BStr`, and also
+  `BString` when `alloc` is enabled.
 */
 
 #![cfg_attr(not(any(feature = "std", test)), no_std)]

--- a/src/unicode/grapheme.rs
+++ b/src/unicode/grapheme.rs
@@ -263,6 +263,7 @@ fn adjust_rev_for_regional_indicator(mut bs: &[u8], i: usize) -> usize {
 
 #[cfg(all(test, feature = "std"))]
 mod tests {
+    #[cfg(not(miri))]
     use ucd_parse::GraphemeClusterBreakTest;
 
     use crate::{ext_slice::ByteSlice, tests::LOSSY_TESTS};
@@ -270,6 +271,7 @@ mod tests {
     use super::*;
 
     #[test]
+    #[cfg(not(miri))]
     fn forward_ucd() {
         for (i, test) in ucdtests().into_iter().enumerate() {
             let given = test.grapheme_clusters.concat();
@@ -292,6 +294,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(miri))]
     fn reverse_ucd() {
         for (i, test) in ucdtests().into_iter().enumerate() {
             let given = test.grapheme_clusters.concat();
@@ -333,15 +336,18 @@ mod tests {
         }
     }
 
+    #[cfg(not(miri))]
     fn uniescape(s: &str) -> String {
         s.chars().flat_map(|c| c.escape_unicode()).collect::<String>()
     }
 
+    #[cfg(not(miri))]
     fn uniescape_vec(strs: &[String]) -> Vec<String> {
         strs.iter().map(|s| uniescape(s)).collect()
     }
 
     /// Return all of the UCD for grapheme breaks.
+    #[cfg(not(miri))]
     fn ucdtests() -> Vec<GraphemeClusterBreakTest> {
         const TESTDATA: &'static str =
             include_str!("data/GraphemeBreakTest.txt");

--- a/src/unicode/sentence.rs
+++ b/src/unicode/sentence.rs
@@ -159,11 +159,13 @@ fn decode_sentence(bs: &[u8]) -> (&str, usize) {
 
 #[cfg(all(test, feature = "std"))]
 mod tests {
+    #[cfg(not(miri))]
     use ucd_parse::SentenceBreakTest;
 
     use crate::ext_slice::ByteSlice;
 
     #[test]
+    #[cfg(not(miri))]
     fn forward_ucd() {
         for (i, test) in ucdtests().into_iter().enumerate() {
             let given = test.sentences.concat();
@@ -199,11 +201,13 @@ mod tests {
         bytes.sentences().collect()
     }
 
+    #[cfg(not(miri))]
     fn strs_to_bstrs<S: AsRef<str>>(strs: &[S]) -> Vec<&[u8]> {
         strs.iter().map(|s| s.as_ref().as_bytes()).collect()
     }
 
     /// Return all of the UCD for sentence breaks.
+    #[cfg(not(miri))]
     fn ucdtests() -> Vec<SentenceBreakTest> {
         const TESTDATA: &'static str =
             include_str!("data/SentenceBreakTest.txt");

--- a/src/unicode/word.rs
+++ b/src/unicode/word.rs
@@ -321,11 +321,13 @@ fn decode_word(bs: &[u8]) -> (&str, usize) {
 
 #[cfg(all(test, feature = "std"))]
 mod tests {
+    #[cfg(not(miri))]
     use ucd_parse::WordBreakTest;
 
     use crate::ext_slice::ByteSlice;
 
     #[test]
+    #[cfg(not(miri))]
     fn forward_ucd() {
         for (i, test) in ucdtests().into_iter().enumerate() {
             let given = test.words.concat();
@@ -395,11 +397,13 @@ mod tests {
         bytes.words_with_breaks().collect()
     }
 
+    #[cfg(not(miri))]
     fn strs_to_bstrs<S: AsRef<str>>(strs: &[S]) -> Vec<&[u8]> {
         strs.iter().map(|s| s.as_ref().as_bytes()).collect()
     }
 
     /// Return all of the UCD for word breaks.
+    #[cfg(not(miri))]
     fn ucdtests() -> Vec<WordBreakTest> {
         const TESTDATA: &'static str = include_str!("data/WordBreakTest.txt");
 

--- a/src/utf8.rs
+++ b/src/utf8.rs
@@ -869,6 +869,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(miri))]
     fn validate_all_codepoints() {
         for i in 0..(0x10FFFF + 1) {
             let cp = match char::from_u32(i) {


### PR DESCRIPTION
The first lines of each commit message should give a good breakdown of what's in here. Notably, this moves the MSRV to Rust 1.60 and makes use of the new `dep:` and `pkg?` feature syntax to get rid of the `serde1-{std,alloc,core}` hack.

cc @epage