### PR TITLE
Regenerate unicode fsm to use once_cell

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,12 +24,12 @@ bench = false
 default = ["std", "unicode"]
 std = ["alloc", "memchr/std", "serde?/std"]
 alloc = ["serde?/alloc"]
-unicode = ["dep:lazy_static", "dep:regex-automata"]
+unicode = ["dep:once_cell", "dep:regex-automata"]
 serde = ["dep:serde"]
 
 [dependencies]
 memchr = { version = "2.4.0", default-features = false }
-lazy_static = { version = "1.2.0", optional = true }
+once_cell = { version = "1.14.0", optional = true }
 regex-automata = { version = "0.1.5", default-features = false, optional = true }
 serde = { version = "1.0.85", default-features = false, optional = true }
 

--- a/src/unicode/fsm/grapheme_break_fwd.rs
+++ b/src/unicode/fsm/grapheme_break_fwd.rs
@@ -5,8 +5,9 @@
 // ucd-generate 0.2.12 is available on crates.io.
 
 #[cfg(target_endian = "big")]
-lazy_static::lazy_static! {
-  pub static ref GRAPHEME_BREAK_FWD: ::regex_automata::SparseDFA<&'static [u8], u16> = {
+pub static GRAPHEME_BREAK_FWD: ::once_cell::sync::Lazy<
+    ::regex_automata::SparseDFA<&'static [u8], u16>,
+> = ::once_cell::sync::Lazy::new(|| {
     #[repr(C)]
     struct Aligned<B: ?Sized> {
         _align: [u8; 0],
@@ -18,15 +19,13 @@ lazy_static::lazy_static! {
         bytes: *include_bytes!("grapheme_break_fwd.bigendian.dfa"),
     };
 
-    unsafe {
-      ::regex_automata::SparseDFA::from_bytes(&ALIGNED.bytes)
-    }
-  };
-}
+    unsafe { ::regex_automata::SparseDFA::from_bytes(&ALIGNED.bytes) }
+});
 
 #[cfg(target_endian = "little")]
-lazy_static::lazy_static! {
-  pub static ref GRAPHEME_BREAK_FWD: ::regex_automata::SparseDFA<&'static [u8], u16> = {
+pub static GRAPHEME_BREAK_FWD: ::once_cell::sync::Lazy<
+    ::regex_automata::SparseDFA<&'static [u8], u16>,
+> = ::once_cell::sync::Lazy::new(|| {
     #[repr(C)]
     struct Aligned<B: ?Sized> {
         _align: [u8; 0],
@@ -38,8 +37,5 @@ lazy_static::lazy_static! {
         bytes: *include_bytes!("grapheme_break_fwd.littleendian.dfa"),
     };
 
-    unsafe {
-      ::regex_automata::SparseDFA::from_bytes(&ALIGNED.bytes)
-    }
-  };
-}
+    unsafe { ::regex_automata::SparseDFA::from_bytes(&ALIGNED.bytes) }
+});

--- a/src/unicode/fsm/grapheme_break_rev.rs
+++ b/src/unicode/fsm/grapheme_break_rev.rs
@@ -5,8 +5,9 @@
 // ucd-generate 0.2.12 is available on crates.io.
 
 #[cfg(target_endian = "big")]
-lazy_static::lazy_static! {
-  pub static ref GRAPHEME_BREAK_REV: ::regex_automata::SparseDFA<&'static [u8], u16> = {
+pub static GRAPHEME_BREAK_REV: ::once_cell::sync::Lazy<
+    ::regex_automata::SparseDFA<&'static [u8], u16>,
+> = ::once_cell::sync::Lazy::new(|| {
     #[repr(C)]
     struct Aligned<B: ?Sized> {
         _align: [u8; 0],
@@ -18,15 +19,13 @@ lazy_static::lazy_static! {
         bytes: *include_bytes!("grapheme_break_rev.bigendian.dfa"),
     };
 
-    unsafe {
-      ::regex_automata::SparseDFA::from_bytes(&ALIGNED.bytes)
-    }
-  };
-}
+    unsafe { ::regex_automata::SparseDFA::from_bytes(&ALIGNED.bytes) }
+});
 
 #[cfg(target_endian = "little")]
-lazy_static::lazy_static! {
-  pub static ref GRAPHEME_BREAK_REV: ::regex_automata::SparseDFA<&'static [u8], u16> = {
+pub static GRAPHEME_BREAK_REV: ::once_cell::sync::Lazy<
+    ::regex_automata::SparseDFA<&'static [u8], u16>,
+> = ::once_cell::sync::Lazy::new(|| {
     #[repr(C)]
     struct Aligned<B: ?Sized> {
         _align: [u8; 0],
@@ -38,8 +37,5 @@ lazy_static::lazy_static! {
         bytes: *include_bytes!("grapheme_break_rev.littleendian.dfa"),
     };
 
-    unsafe {
-      ::regex_automata::SparseDFA::from_bytes(&ALIGNED.bytes)
-    }
-  };
-}
+    unsafe { ::regex_automata::SparseDFA::from_bytes(&ALIGNED.bytes) }
+});

--- a/src/unicode/fsm/regional_indicator_rev.rs
+++ b/src/unicode/fsm/regional_indicator_rev.rs
@@ -5,8 +5,9 @@
 // ucd-generate 0.2.12 is available on crates.io.
 
 #[cfg(target_endian = "big")]
-lazy_static::lazy_static! {
-  pub static ref REGIONAL_INDICATOR_REV: ::regex_automata::DenseDFA<&'static [u8], u8> = {
+pub static REGIONAL_INDICATOR_REV: ::once_cell::sync::Lazy<
+    ::regex_automata::DenseDFA<&'static [u8], u8>,
+> = ::once_cell::sync::Lazy::new(|| {
     #[repr(C)]
     struct Aligned<B: ?Sized> {
         _align: [u8; 0],
@@ -18,15 +19,13 @@ lazy_static::lazy_static! {
         bytes: *include_bytes!("regional_indicator_rev.bigendian.dfa"),
     };
 
-    unsafe {
-      ::regex_automata::DenseDFA::from_bytes(&ALIGNED.bytes)
-    }
-  };
-}
+    unsafe { ::regex_automata::DenseDFA::from_bytes(&ALIGNED.bytes) }
+});
 
 #[cfg(target_endian = "little")]
-lazy_static::lazy_static! {
-  pub static ref REGIONAL_INDICATOR_REV: ::regex_automata::DenseDFA<&'static [u8], u8> = {
+pub static REGIONAL_INDICATOR_REV: ::once_cell::sync::Lazy<
+    ::regex_automata::DenseDFA<&'static [u8], u8>,
+> = ::once_cell::sync::Lazy::new(|| {
     #[repr(C)]
     struct Aligned<B: ?Sized> {
         _align: [u8; 0],
@@ -38,8 +37,5 @@ lazy_static::lazy_static! {
         bytes: *include_bytes!("regional_indicator_rev.littleendian.dfa"),
     };
 
-    unsafe {
-      ::regex_automata::DenseDFA::from_bytes(&ALIGNED.bytes)
-    }
-  };
-}
+    unsafe { ::regex_automata::DenseDFA::from_bytes(&ALIGNED.bytes) }
+});

--- a/src/unicode/fsm/sentence_break_fwd.rs
+++ b/src/unicode/fsm/sentence_break_fwd.rs
@@ -5,8 +5,9 @@
 // ucd-generate 0.2.12 is available on crates.io.
 
 #[cfg(target_endian = "big")]
-lazy_static::lazy_static! {
-  pub static ref SENTENCE_BREAK_FWD: ::regex_automata::SparseDFA<&'static [u8], u32> = {
+pub static SENTENCE_BREAK_FWD: ::once_cell::sync::Lazy<
+    ::regex_automata::SparseDFA<&'static [u8], u32>,
+> = ::once_cell::sync::Lazy::new(|| {
     #[repr(C)]
     struct Aligned<B: ?Sized> {
         _align: [u8; 0],
@@ -18,15 +19,13 @@ lazy_static::lazy_static! {
         bytes: *include_bytes!("sentence_break_fwd.bigendian.dfa"),
     };
 
-    unsafe {
-      ::regex_automata::SparseDFA::from_bytes(&ALIGNED.bytes)
-    }
-  };
-}
+    unsafe { ::regex_automata::SparseDFA::from_bytes(&ALIGNED.bytes) }
+});
 
 #[cfg(target_endian = "little")]
-lazy_static::lazy_static! {
-  pub static ref SENTENCE_BREAK_FWD: ::regex_automata::SparseDFA<&'static [u8], u32> = {
+pub static SENTENCE_BREAK_FWD: ::once_cell::sync::Lazy<
+    ::regex_automata::SparseDFA<&'static [u8], u32>,
+> = ::once_cell::sync::Lazy::new(|| {
     #[repr(C)]
     struct Aligned<B: ?Sized> {
         _align: [u8; 0],
@@ -38,8 +37,5 @@ lazy_static::lazy_static! {
         bytes: *include_bytes!("sentence_break_fwd.littleendian.dfa"),
     };
 
-    unsafe {
-      ::regex_automata::SparseDFA::from_bytes(&ALIGNED.bytes)
-    }
-  };
-}
+    unsafe { ::regex_automata::SparseDFA::from_bytes(&ALIGNED.bytes) }
+});

--- a/src/unicode/fsm/simple_word_fwd.rs
+++ b/src/unicode/fsm/simple_word_fwd.rs
@@ -5,8 +5,9 @@
 // ucd-generate 0.2.12 is available on crates.io.
 
 #[cfg(target_endian = "big")]
-lazy_static::lazy_static! {
-  pub static ref SIMPLE_WORD_FWD: ::regex_automata::SparseDFA<&'static [u8], u16> = {
+pub static SIMPLE_WORD_FWD: ::once_cell::sync::Lazy<
+    ::regex_automata::SparseDFA<&'static [u8], u16>,
+> = ::once_cell::sync::Lazy::new(|| {
     #[repr(C)]
     struct Aligned<B: ?Sized> {
         _align: [u8; 0],
@@ -18,15 +19,13 @@ lazy_static::lazy_static! {
         bytes: *include_bytes!("simple_word_fwd.bigendian.dfa"),
     };
 
-    unsafe {
-      ::regex_automata::SparseDFA::from_bytes(&ALIGNED.bytes)
-    }
-  };
-}
+    unsafe { ::regex_automata::SparseDFA::from_bytes(&ALIGNED.bytes) }
+});
 
 #[cfg(target_endian = "little")]
-lazy_static::lazy_static! {
-  pub static ref SIMPLE_WORD_FWD: ::regex_automata::SparseDFA<&'static [u8], u16> = {
+pub static SIMPLE_WORD_FWD: ::once_cell::sync::Lazy<
+    ::regex_automata::SparseDFA<&'static [u8], u16>,
+> = ::once_cell::sync::Lazy::new(|| {
     #[repr(C)]
     struct Aligned<B: ?Sized> {
         _align: [u8; 0],
@@ -38,8 +37,5 @@ lazy_static::lazy_static! {
         bytes: *include_bytes!("simple_word_fwd.littleendian.dfa"),
     };
 
-    unsafe {
-      ::regex_automata::SparseDFA::from_bytes(&ALIGNED.bytes)
-    }
-  };
-}
+    unsafe { ::regex_automata::SparseDFA::from_bytes(&ALIGNED.bytes) }
+});

--- a/src/unicode/fsm/whitespace_anchored_fwd.rs
+++ b/src/unicode/fsm/whitespace_anchored_fwd.rs
@@ -5,8 +5,9 @@
 // ucd-generate 0.2.12 is available on crates.io.
 
 #[cfg(target_endian = "big")]
-lazy_static::lazy_static! {
-  pub static ref WHITESPACE_ANCHORED_FWD: ::regex_automata::DenseDFA<&'static [u8], u8> = {
+pub static WHITESPACE_ANCHORED_FWD: ::once_cell::sync::Lazy<
+    ::regex_automata::DenseDFA<&'static [u8], u8>,
+> = ::once_cell::sync::Lazy::new(|| {
     #[repr(C)]
     struct Aligned<B: ?Sized> {
         _align: [u8; 0],
@@ -18,15 +19,13 @@ lazy_static::lazy_static! {
         bytes: *include_bytes!("whitespace_anchored_fwd.bigendian.dfa"),
     };
 
-    unsafe {
-      ::regex_automata::DenseDFA::from_bytes(&ALIGNED.bytes)
-    }
-  };
-}
+    unsafe { ::regex_automata::DenseDFA::from_bytes(&ALIGNED.bytes) }
+});
 
 #[cfg(target_endian = "little")]
-lazy_static::lazy_static! {
-  pub static ref WHITESPACE_ANCHORED_FWD: ::regex_automata::DenseDFA<&'static [u8], u8> = {
+pub static WHITESPACE_ANCHORED_FWD: ::once_cell::sync::Lazy<
+    ::regex_automata::DenseDFA<&'static [u8], u8>,
+> = ::once_cell::sync::Lazy::new(|| {
     #[repr(C)]
     struct Aligned<B: ?Sized> {
         _align: [u8; 0],
@@ -38,8 +37,5 @@ lazy_static::lazy_static! {
         bytes: *include_bytes!("whitespace_anchored_fwd.littleendian.dfa"),
     };
 
-    unsafe {
-      ::regex_automata::DenseDFA::from_bytes(&ALIGNED.bytes)
-    }
-  };
-}
+    unsafe { ::regex_automata::DenseDFA::from_bytes(&ALIGNED.bytes) }
+});

--- a/src/unicode/fsm/whitespace_anchored_rev.rs
+++ b/src/unicode/fsm/whitespace_anchored_rev.rs
@@ -5,8 +5,9 @@
 // ucd-generate 0.2.12 is available on crates.io.
 
 #[cfg(target_endian = "big")]
-lazy_static::lazy_static! {
-  pub static ref WHITESPACE_ANCHORED_REV: ::regex_automata::DenseDFA<&'static [u16], u16> = {
+pub static WHITESPACE_ANCHORED_REV: ::once_cell::sync::Lazy<
+    ::regex_automata::DenseDFA<&'static [u16], u16>,
+> = ::once_cell::sync::Lazy::new(|| {
     #[repr(C)]
     struct Aligned<B: ?Sized> {
         _align: [u16; 0],
@@ -18,15 +19,13 @@ lazy_static::lazy_static! {
         bytes: *include_bytes!("whitespace_anchored_rev.bigendian.dfa"),
     };
 
-    unsafe {
-      ::regex_automata::DenseDFA::from_bytes(&ALIGNED.bytes)
-    }
-  };
-}
+    unsafe { ::regex_automata::DenseDFA::from_bytes(&ALIGNED.bytes) }
+});
 
 #[cfg(target_endian = "little")]
-lazy_static::lazy_static! {
-  pub static ref WHITESPACE_ANCHORED_REV: ::regex_automata::DenseDFA<&'static [u16], u16> = {
+pub static WHITESPACE_ANCHORED_REV: ::once_cell::sync::Lazy<
+    ::regex_automata::DenseDFA<&'static [u16], u16>,
+> = ::once_cell::sync::Lazy::new(|| {
     #[repr(C)]
     struct Aligned<B: ?Sized> {
         _align: [u16; 0],
@@ -38,8 +37,5 @@ lazy_static::lazy_static! {
         bytes: *include_bytes!("whitespace_anchored_rev.littleendian.dfa"),
     };
 
-    unsafe {
-      ::regex_automata::DenseDFA::from_bytes(&ALIGNED.bytes)
-    }
-  };
-}
+    unsafe { ::regex_automata::DenseDFA::from_bytes(&ALIGNED.bytes) }
+});

--- a/src/unicode/fsm/word_break_fwd.rs
+++ b/src/unicode/fsm/word_break_fwd.rs
@@ -5,8 +5,9 @@
 // ucd-generate 0.2.12 is available on crates.io.
 
 #[cfg(target_endian = "big")]
-lazy_static::lazy_static! {
-  pub static ref WORD_BREAK_FWD: ::regex_automata::SparseDFA<&'static [u8], u32> = {
+pub static WORD_BREAK_FWD: ::once_cell::sync::Lazy<
+    ::regex_automata::SparseDFA<&'static [u8], u32>,
+> = ::once_cell::sync::Lazy::new(|| {
     #[repr(C)]
     struct Aligned<B: ?Sized> {
         _align: [u8; 0],
@@ -18,15 +19,13 @@ lazy_static::lazy_static! {
         bytes: *include_bytes!("word_break_fwd.bigendian.dfa"),
     };
 
-    unsafe {
-      ::regex_automata::SparseDFA::from_bytes(&ALIGNED.bytes)
-    }
-  };
-}
+    unsafe { ::regex_automata::SparseDFA::from_bytes(&ALIGNED.bytes) }
+});
 
 #[cfg(target_endian = "little")]
-lazy_static::lazy_static! {
-  pub static ref WORD_BREAK_FWD: ::regex_automata::SparseDFA<&'static [u8], u32> = {
+pub static WORD_BREAK_FWD: ::once_cell::sync::Lazy<
+    ::regex_automata::SparseDFA<&'static [u8], u32>,
+> = ::once_cell::sync::Lazy::new(|| {
     #[repr(C)]
     struct Aligned<B: ?Sized> {
         _align: [u8; 0],
@@ -38,8 +37,5 @@ lazy_static::lazy_static! {
         bytes: *include_bytes!("word_break_fwd.littleendian.dfa"),
     };
 
-    unsafe {
-      ::regex_automata::SparseDFA::from_bytes(&ALIGNED.bytes)
-    }
-  };
-}
+    unsafe { ::regex_automata::SparseDFA::from_bytes(&ALIGNED.bytes) }
+});


### PR DESCRIPTION
Closes #124. Generated by https://github.com/BurntSushi/ucd-generate/pull/52:

```bash
# build ucd-generate PR:
cargo install --path . --force

# then in bstr:
scripts/generate-unicode-data
cargo fmt
```