### PR TITLE
Set up a Miri job in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,3 +101,15 @@ jobs:
       working-directory: ./bench
       run: |
         cargo fmt -- --check
+
+  miri:
+    name: miri
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@miri
+    - run: cargo miri test --lib --verbose
+      env:
+        MIRIFLAGS: -Zmiri-strict-provenance


### PR DESCRIPTION
I confirmed this job catches the problem when either of 140831a936bc560308b3ed7c0439b509f2a679d5 or 14af7d3056060e1dd22e1433d95eaed82bbcd39a is reverted.

Since 0ee9b5e9c8c81020ac93de75f93e26664a779c42 the test suite takes 14 seconds to run under Miri on my machine. In GitHub Actions it looks like this job takes around 1m50s end-to-end including Rust install and building a Miri sysroot, which is significantly faster than the current `test (stable)` job at 4m40s and faster than the `test (win-gnu)` and `test (win-msvc)` jobs at ~2m40s, so this addition shouldn't cause CI to complete slower overall.