### PR TITLE
Set rust-version in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ license = "MIT OR Apache-2.0"
 categories = ["text-processing", "encoding"]
 exclude = ["/.github"]
 edition = "2021"
+rust-version = "1.60"
 resolver = "2"
 
 [workspace]


### PR DESCRIPTION
Now that the MSRV is higher than 1.56 it can be set in Cargo.toml.