### PR TITLE
fix: make serde traits available once again

### DIFF
--- a/src/impls.rs
+++ b/src/impls.rs
@@ -725,7 +725,7 @@ mod bstr {
     impl_partial_ord!(&'a BStr, String);
 }
 
-#[cfg(feature = "serde1-core")]
+#[cfg(feature = "serde")]
 mod bstr_serde {
     use core::fmt;
 
@@ -783,7 +783,7 @@ mod bstr_serde {
     }
 }
 
-#[cfg(feature = "serde1-alloc")]
+#[cfg(all(feature = "serde", feature = "alloc"))]
 mod bstring_serde {
     use core::{cmp, fmt};
 


### PR DESCRIPTION
It appears that during the serde feature restructuring the serde implementation
ended up behind an unused feature toggle.

Currently the tests aren't able to catch that as there seems to be no test that is
using the serde trait implementation that I didn't feel comfortable to add just yet.

This adjustment should allow `gitoxide` to upgrade to 1.0 eventually.
