### PR TITLE
Implement `ByteSlice` for `[u8; N]`

### DIFF
--- a/src/ext_slice.rs
+++ b/src/ext_slice.rs
@@ -87,10 +87,23 @@ impl ByteSlice for [u8] {
     }
 }
 
+impl<const N: usize> ByteSlice for [u8; N] {
+    #[inline]
+    fn as_bytes(&self) -> &[u8] {
+        self
+    }
+
+    #[inline]
+    fn as_bytes_mut(&mut self) -> &mut [u8] {
+        self
+    }
+}
+
 /// Ensure that callers cannot implement `ByteSlice` by making an
 /// umplementable trait its super trait.
 pub trait Sealed {}
 impl Sealed for [u8] {}
+impl<const N: usize> Sealed for [u8; N] {}
 
 /// A trait that extends `&[u8]` with string oriented methods.
 pub trait ByteSlice: Sealed {


### PR DESCRIPTION
Fixes #86.