### PR TITLE
Drop `readme` and `resolver` fields from Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,14 +6,12 @@ description = "A string type that is not required to be valid UTF-8."
 documentation = "https://docs.rs/bstr"
 homepage = "https://github.com/BurntSushi/bstr"
 repository = "https://github.com/BurntSushi/bstr"
-readme = "README.md"
 keywords = ["string", "str", "byte", "bytes", "text"]
 license = "MIT OR Apache-2.0"
 categories = ["text-processing", "encoding"]
 exclude = ["/.github"]
 edition = "2021"
 rust-version = "1.60"
-resolver = "2"
 
 [workspace]
 members = ["bench"]


### PR DESCRIPTION
The values they set don't differ from the defaults. From the manifest reference:

`readme`:
"If no value is specified for this field, and a file named README.md, README.txt or README exists in the package root, then the name of that file will be used."

`resolver`:
"The default is "2" if the root package specifies edition = "2021" or a newer edition."