### PR TITLE
ci: setup caching for build artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,8 @@ jobs:
       uses: dtolnay/rust-toolchain@master
       with:
         toolchain: ${{ matrix.rust }}
+    - name: Setup cache
+      uses: Swatinem/rust-cache@v2
     - run: cargo build --verbose
     - run: cargo doc --verbose
     # We run a few other builds, but only on one instance to avoid doing
@@ -108,6 +110,8 @@ jobs:
       uses: actions/checkout@v3
     - name: Install Rust
       uses: dtolnay/rust-toolchain@miri
+    - name: Setup cache
+      uses: Swatinem/rust-cache@v2
     - run: cargo miri test --lib --verbose
       env:
         MIRIFLAGS: -Zmiri-strict-provenance


### PR DESCRIPTION
Reduces build time by 0.5-1.5 minutes depending on the job.