### PR TITLE
ci: use latest runner images in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,25 +18,25 @@ jobs:
         build: [pinned, stable, beta, nightly, macos, win-msvc, win-gnu]
         include:
         - build: pinned
-          os: ubuntu-18.04
+          os: ubuntu-22.04
           rust: 1.60.0
         - build: stable
-          os: ubuntu-18.04
+          os: ubuntu-22.04
           rust: stable
         - build: beta
-          os: ubuntu-18.04
+          os: ubuntu-22.04
           rust: beta
         - build: nightly
-          os: ubuntu-18.04
+          os: ubuntu-22.04
           rust: nightly
         - build: macos
-          os: macos-latest
+          os: macos-12
           rust: stable
         - build: win-msvc
-          os: windows-2019
+          os: windows-2022
           rust: stable
         - build: win-gnu
-          os: windows-2019
+          os: windows-2022
           rust: stable-x86_64-gnu
     steps:
     - name: Checkout repository
@@ -83,7 +83,7 @@ jobs:
 
   rustfmt:
     name: rustfmt
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,8 +93,7 @@ jobs:
         toolchain: stable
         components: rustfmt
     - name: Check formatting
-      run: |
-        cargo fmt -- --check
+      run: cargo fmt --check
 
   miri:
     name: miri

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,10 +95,6 @@ jobs:
     - name: Check formatting
       run: |
         cargo fmt -- --check
-    - name: Check formatting in ./bench
-      working-directory: ./bench
-      run: |
-        cargo fmt -- --check
 
   miri:
     name: miri


### PR DESCRIPTION
The `ubuntu-18.04` image is deprecated and will be removed by 2023-04-01 [1][2] with scheduled brownouts starting on 2022-10-03. Update all images to the latest available versions.

I've also thrown in two minor cleanup commits.