### PR TITLE
fix for target_pointer_width = "16"

### DIFF
--- a/src/byteset/scalar.rs
+++ b/src/byteset/scalar.rs
@@ -4,6 +4,9 @@
 
 use core::{cmp, usize};
 
+#[cfg(target_pointer_width = "16")]
+const USIZE_BYTES: usize = 2;
+
 #[cfg(target_pointer_width = "32")]
 const USIZE_BYTES: usize = 4;
 


### PR DESCRIPTION
It is required for 8-bit targets like AVR or MOS 6502