### PR TITLE
Fix typos

### DIFF
--- a/src/ext_slice.rs
+++ b/src/ext_slice.rs
@@ -1311,11 +1311,11 @@ pub trait ByteSlice: Sealed {
         SplitReverse::new(self.as_bytes(), splitter.as_ref())
     }
 
-    /// Split this byte string at the first occurance of `splitter`.
+    /// Split this byte string at the first occurrence of `splitter`.
     ///
     /// If the `splitter` is found in the byte string, returns a tuple
-    /// containing the parts of the string before and after the first occurance
-    /// of `splitter` respectively. Otherwise, if there are no occurances of
+    /// containing the parts of the string before and after the first occurrence
+    /// of `splitter` respectively. Otherwise, if there are no occurrences of
     /// `splitter` in the byte string, returns `None`.
     ///
     /// The splitter may be any type that can be cheaply converted into a
@@ -1355,11 +1355,11 @@ pub trait ByteSlice: Sealed {
         Some((&bytes[..start], &bytes[end..]))
     }
 
-    /// Split this byte string at the last occurance of `splitter`.
+    /// Split this byte string at the last occurrence of `splitter`.
     ///
     /// If the `splitter` is found in the byte string, returns a tuple
-    /// containing the parts of the string before and after the last occurance
-    /// of `splitter`, respectively. Otherwise, if there are no occurances of
+    /// containing the parts of the string before and after the last occurrence
+    /// of `splitter`, respectively. Otherwise, if there are no occurrences of
     /// `splitter` in the byte string, returns `None`.
     ///
     /// The splitter may be any type that can be cheaply converted into a
@@ -1902,7 +1902,7 @@ pub trait ByteSlice: Sealed {
     /// assert_eq!(vec![(0, 5, "à̖"), (5, 13, "🇺🇸")], graphemes);
     /// ```
     ///
-    /// This example shows what happens when invalid UTF-8 is enountered. Note
+    /// This example shows what happens when invalid UTF-8 is encountered. Note
     /// that the offsets are valid indices into the original string, and do
     /// not necessarily correspond to the length of the `&str` returned!
     ///

--- a/src/io.rs
+++ b/src/io.rs
@@ -13,7 +13,7 @@ use std::io;
 
 use crate::{ext_slice::ByteSlice, ext_vec::ByteVec};
 
-/// An extention trait for
+/// An extension trait for
 /// [`std::io::BufRead`](https://doc.rust-lang.org/std/io/trait.BufRead.html)
 /// which provides convenience APIs for dealing with byte strings.
 pub trait BufReadExt: io::BufRead {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@ additional string oriented methods. Operations such as iterating over
 graphemes, searching for substrings, replacing substrings, trimming and case
 conversion are examples of things not provided on the standard library `&[u8]`
 APIs but are provided by this crate. For example, this code iterates over all
-of occurrences of a subtring:
+of occurrences of a substring:
 
 ```
 use bstr::ByteSlice;

--- a/src/utf8.rs
+++ b/src/utf8.rs
@@ -388,7 +388,7 @@ impl<'a> ::core::iter::FusedIterator for Utf8Chunks<'a> {}
 /// assert_eq!(err.error_len(), Some(3));
 ///
 /// // In contrast to the above which contains a single invalid prefix,
-/// // consider the case of multiple individal bytes that are never valid
+/// // consider the case of multiple individual bytes that are never valid
 /// // prefixes. Note how the value of error_len changes!
 /// let s = b"foobar\xFF\xFFquux";
 /// let err = s.to_str().unwrap_err();


### PR DESCRIPTION
Found via `codespell -S *.txt -L crate,upto,fo`