### PR TITLE
Make `Sealed` super trait impossible to export

### DIFF
--- a/src/ext_slice.rs
+++ b/src/ext_slice.rs
@@ -101,12 +101,16 @@ impl<const N: usize> ByteSlice for [u8; N] {
 
 /// Ensure that callers cannot implement `ByteSlice` by making an
 /// umplementable trait its super trait.
-pub trait Sealed {}
-impl Sealed for [u8] {}
-impl<const N: usize> Sealed for [u8; N] {}
+mod private {
+    pub trait Sealed {}
+}
+impl private::Sealed for [u8] {}
+impl<const N: usize> private::Sealed for [u8; N] {}
 
 /// A trait that extends `&[u8]` with string oriented methods.
-pub trait ByteSlice: Sealed {
+///
+/// This trait is sealed and cannot be implemented outside of `bstr`.
+pub trait ByteSlice: private::Sealed {
     /// A method for accessing the raw bytes of this type. This is always a
     /// no-op and callers shouldn't care about it. This only exists for making
     /// the extension trait work.

--- a/src/ext_vec.rs
+++ b/src/ext_vec.rs
@@ -104,8 +104,10 @@ impl ByteVec for Vec<u8> {
 
 /// Ensure that callers cannot implement `ByteSlice` by making an
 /// umplementable trait its super trait.
-pub trait Sealed {}
-impl Sealed for Vec<u8> {}
+mod private {
+    pub trait Sealed {}
+}
+impl private::Sealed for Vec<u8> {}
 
 /// A trait that extends `Vec<u8>` with string oriented methods.
 ///
@@ -119,7 +121,9 @@ impl Sealed for Vec<u8> {}
 /// let s = Vec::from_slice(b"abc"); // NOT ByteVec::from_slice("...")
 /// assert_eq!(s, B("abc"));
 /// ```
-pub trait ByteVec: Sealed {
+///
+/// This trait is sealed and cannot be implemented outside of `bstr`.
+pub trait ByteVec: private::Sealed {
     /// A method for accessing the raw vector bytes of this type. This is
     /// always a no-op and callers shouldn't care about it. This only exists
     /// for making the extension trait work.


### PR DESCRIPTION
Drive by refactor after revisiting #133.

The `Sealed` trait in `crate::ext_slice` and `crate::ext_vec` is marked `pub` and is reachable from the crate root, which means there is a (small) risk the trait may be accidentally exported as public API.

The sealed trait trick works so long as the trait is marked `pub` even if the trait is not public to the whole crate.

This commit wraps `pub trait Sealed` in a private module, which ensures the sealed trait in `crate::ext_slice` may only be used for implementing `ByteSlice` (and similarly for `crate::ext_vec` and `ByteVec`).

The new sealed trait is defined and used like this:

```rust
mod private {
    pub trait Sealed {}
}

impl private::Sealed for &[u8] {}

trait ByteSlice: private::Sealed {
    // ...
}
```

This approach is discussed at
https://rust-lang.github.io/api-guidelines/future-proofing.html.

A short addition to the `ByteSlice` and `ByteVec` traits indicate that these traits are sealed and not meant to be implemented outside of `bstr`.