### PR TITLE
`impl Clone for Box<BStr>`

### DIFF
--- a/src/impls.rs
+++ b/src/impls.rs
@@ -667,6 +667,14 @@ mod bstr {
         }
     }
 
+    #[cfg(feature = "alloc")]
+    impl Clone for Box<BStr> {
+        #[inline]
+        fn clone(&self) -> Self {
+            BStr::from_boxed_bytes(self.as_bytes().into())
+        }
+    }
+
     impl Eq for BStr {}
 
     impl PartialEq<BStr> for BStr {


### PR DESCRIPTION
Since the default blanket impl of `Clone for Box<T>` requires that `T: Sized`, we could not previously clone `Box<BStr>`. This came up when I tried to use `Box<BStr>` in a `struct` with `#[derive(Clone)]`.

Thankfully, the orphan rules have been relaxed (can't recall in which version this happened...) so we can provide this impl ourselves since we control `BStr` and there's no overlap with the blanket impl (due to the `T: Sized` bound).