### PR TITLE
api: impl `ByteSlice` for `Cow<'_, [u8]>`

### DIFF
--- a/src/ext_slice.rs
+++ b/src/ext_slice.rs
@@ -99,6 +99,19 @@ impl<const N: usize> ByteSlice for [u8; N] {
     }
 }
 
+#[cfg(feature = "alloc")]
+impl<'a> ByteSlice for Cow<'a, [u8]> {
+    #[inline]
+    fn as_bytes(&self) -> &[u8] {
+        self
+    }
+
+    #[inline]
+    fn as_bytes_mut(&mut self) -> &mut [u8] {
+        self.to_mut()
+    }
+}
+
 /// Ensure that callers cannot implement `ByteSlice` by making an
 /// umplementable trait its super trait.
 mod private {
@@ -106,6 +119,8 @@ mod private {
 }
 impl private::Sealed for [u8] {}
 impl<const N: usize> private::Sealed for [u8; N] {}
+#[cfg(feature = "alloc")]
+impl<'a> private::Sealed for Cow<'a, [u8]> {}
 
 /// A trait that extends `&[u8]` with string oriented methods.
 ///


### PR DESCRIPTION
I often pass around error messages as `Cow<'static, [u8]>`. Asserting on output of these messages in tests is a bit verbose because I must do `message.as_ref().as_bstr()`. This impl allows writing `message.as_bstr()` instead.

Unfortunately, this impl introduces a potentially hidden allocation in `<Cow<'_, [u8]> as ByteSlice>::as_bytes_mut()`. This violates the Rust API convention that "as_"-prefixed APIs are cheap to call. Because of that, I'm not sure if you consider this impl acceptable for inclusion in `bstr`. If that's the case, feel free to close this PR.