### PR TITLE
`impl AsRef<BStr> for BStr`.

### DIFF
--- a/src/impls.rs
+++ b/src/impls.rs
@@ -563,6 +563,13 @@ mod bstr {
         }
     }
 
+    impl AsRef<BStr> for BStr {
+        #[inline]
+        fn as_ref(&self) -> &BStr {
+            self
+        }
+    }
+
     impl AsRef<BStr> for [u8] {
         #[inline]
         fn as_ref(&self) -> &BStr {


### PR DESCRIPTION
I've currently got code that requires two separate function signatures to quote `BStr`-like things:

```rust
fn quoted_bstr(s: &BStr) -> String {
    if s.is_ascii() && !s.contains(&b'\'') {
        format!("'{}'", s)
    } else {
        format!("{:?}", s)
    }
}

fn quoted<B: AsRef<BStr>>(s: B) -> String {
    quoted_bstr(s.as_ref())
}
```

I'd like to suggest adding `impl AsRef<BStr> for BStr` to allow functions that accept `AsRef<BStr>` to also accept `BStr` itself, e.g.:

```rust
fn quoted<B: AsRef<BStr>>(s: B) -> String {
    let s = s.as_ref();
    if s.is_ascii() && !s.contains(&b'\'') {
        format!("'{}'", s)
    } else {
        format!("{:?}", s)
    }
}
```

Would this addition cause any problems?  I see the following discussion in the documentation regarding why there's no blanket implementation `impl<T: ?Sized> AsRef<T> for T`, but I don't understand all the implications: <https://doc.rust-lang.org/std/convert/trait.AsRef.html#reflexivity>

If this addition is undesirable, is there another way I'm overlooking that avoids the need for separate functions as shown above?

Thanks,
Michael Henry
