### PR TITLE
Fix UB due to unaligned reads

### DIFF
--- a/src/ascii.rs
+++ b/src/ascii.rs
@@ -78,8 +78,8 @@ fn first_non_ascii_byte_fallback(slice: &[u8]) -> usize {
             while ptr <= ptr_sub(end_ptr, FALLBACK_LOOP_SIZE) {
                 debug_assert_eq!(0, (ptr as usize) % USIZE_BYTES);
 
-                let a = *(ptr as *const usize);
-                let b = *(ptr_add(ptr, USIZE_BYTES) as *const usize);
+                let a = read_unaligned_usize(ptr);
+                let b = read_unaligned_usize(ptr_add(ptr, USIZE_BYTES));
                 if (a | b) & ASCII_MASK != 0 {
                     // What a kludge. We wrap the position finding code into
                     // a non-inlineable function, which makes the codegen in
@@ -92,8 +92,9 @@ fn first_non_ascii_byte_fallback(slice: &[u8]) -> usize {
                         start_ptr: *const u8,
                         ptr: *const u8,
                     ) -> usize {
-                        let a = *(ptr as *const usize);
-                        let b = *(ptr_add(ptr, USIZE_BYTES) as *const usize);
+                        let a = read_unaligned_usize(ptr);
+                        let b =
+                            read_unaligned_usize(ptr_add(ptr, USIZE_BYTES));
 
                         let mut at = sub(ptr, start_ptr);
                         let maska = a & ASCII_MASK;

--- a/src/byteset/scalar.rs
+++ b/src/byteset/scalar.rs
@@ -48,8 +48,8 @@ pub fn inv_memchr(n1: u8, haystack: &[u8]) -> Option<usize> {
         while loop_size == LOOP_SIZE && ptr <= end_ptr.sub(loop_size) {
             debug_assert_eq!(0, (ptr as usize) % USIZE_BYTES);
 
-            let a = *(ptr as *const usize);
-            let b = *(ptr.add(USIZE_BYTES) as *const usize);
+            let a = read_unaligned_usize(ptr);
+            let b = read_unaligned_usize(ptr.add(USIZE_BYTES));
             let eqa = (a ^ vn1) != 0;
             let eqb = (b ^ vn1) != 0;
             if eqa || eqb {
@@ -87,8 +87,8 @@ pub fn inv_memrchr(n1: u8, haystack: &[u8]) -> Option<usize> {
         while loop_size == LOOP_SIZE && ptr >= start_ptr.add(loop_size) {
             debug_assert_eq!(0, (ptr as usize) % USIZE_BYTES);
 
-            let a = *(ptr.sub(2 * USIZE_BYTES) as *const usize);
-            let b = *(ptr.sub(1 * USIZE_BYTES) as *const usize);
+            let a = read_unaligned_usize(ptr.sub(2 * USIZE_BYTES));
+            let b = read_unaligned_usize(ptr.sub(1 * USIZE_BYTES));
             let eqa = (a ^ vn1) != 0;
             let eqb = (b ^ vn1) != 0;
             if eqa || eqb {


### PR DESCRIPTION
I ran into this issue when running Miri on a crate that depends on `bstr`. The issue even shows up when running the `bstr` test suite with `MIRIFLAGS=-Zmiri-symbolic-alignment-check`. 

Example backtrace:

```
test ascii::tests::positive_fallback_forward ... error: Undefined Behavior: accessing memory with alignment 1, but alignment 8 is required
   --> src/ascii.rs:81:25
    |
81  |                 let a = *(ptr as *const usize);
    |                         ^^^^^^^^^^^^^^^^^^^^^^ accessing memory with alignment 1, but alignment 8 is required
    |
    = help: this usually indicates that your program performed an invalid operation and caused Undefined Behavior
    = help: but due to `-Zmiri-symbolic-alignment-check`, alignment errors can also be false positives
    = note: BACKTRACE:
    = note: inside `ascii::first_non_ascii_byte_fallback` at src/ascii.rs:81:25: 81:47
note: inside `ascii::tests::positive_fallback_forward`
   --> src/ascii.rs:278:17
    |
278 |                 first_non_ascii_byte_fallback(s.as_bytes()),
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
note: inside closure
   --> src/ascii.rs:273:36
    |
272 |     #[test]
    |     ------- in this procedural macro expansion
273 |     fn positive_fallback_forward() {
    |                                    ^
    = note: this error originates in the attribute macro `test` (in Nightly builds, run with -Z macro-backtrace for more info)
```