### PR TITLE
Use `cargo add` rather than a `Cargo.toml` stanza

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,7 @@ incorrect to require valid UTF-8.
 
 ### Usage
 
-Add this to your `Cargo.toml`:
-
-```toml
-[dependencies]
-bstr = "1"
-```
-
+`cargo add bstr`
 
 ### Examples
 


### PR DESCRIPTION
This automatically uses the current version, which means users of bstr
who rely on new bstr APIs will have an appropriate dependency.
