### PR TITLE
Gate `UnescapeBytes` struct on alloc feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,9 @@ jobs:
         - build: win-gnu
           os: windows-latest
           rust: stable-x86_64-gnu
+    env:
+      RUSTFLAGS: -D warnings
+      RUST_BACKTRACE: 1
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3

--- a/src/escape_bytes.rs
+++ b/src/escape_bytes.rs
@@ -129,11 +129,13 @@ enum EscapeState {
 /// expose this for core-only use cases too. I'm just not quite sure what the
 /// API should be.
 #[derive(Clone, Debug)]
+#[cfg(feature = "alloc")]
 pub(crate) struct UnescapeBytes<I> {
     it: I,
     state: UnescapeState,
 }
 
+#[cfg(feature = "alloc")]
 impl<I: Iterator<Item = char>> UnescapeBytes<I> {
     pub(crate) fn new<T: IntoIterator<IntoIter = I>>(
         t: T,
@@ -142,6 +144,7 @@ impl<I: Iterator<Item = char>> UnescapeBytes<I> {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<I: Iterator<Item = char>> Iterator for UnescapeBytes<I> {
     type Item = u8;
 
@@ -265,6 +268,7 @@ impl<I: Iterator<Item = char>> Iterator for UnescapeBytes<I> {
 
 /// The state used by the FSM in the unescaping iterator.
 #[derive(Clone, Debug)]
+#[cfg(feature = "alloc")]
 enum UnescapeState {
     /// The start state. Look for an escape sequence, otherwise emit the next
     /// codepoint as-is.
@@ -283,6 +287,7 @@ enum UnescapeState {
     HexSecond(char),
 }
 
+#[cfg(feature = "alloc")]
 impl UnescapeState {
     /// Create a new `Bytes` variant with the given slice.
     ///
@@ -337,6 +342,7 @@ impl UnescapeState {
 /// # Panics
 ///
 /// This panics if `ch` is not in `[0-9A-Fa-f]`.
+#[cfg(feature = "alloc")]
 fn char_to_hexdigit(ch: char) -> u8 {
     u8::try_from(ch.to_digit(16).unwrap()).unwrap()
 }


### PR DESCRIPTION
`UnescapeBytes` is documented to require the `alloc` feature and is not exposed in its raw iterator form. When building `bstr` with no default features, it emits a dead code warning:

```console
$ cargo check --no-default-features
   Compiling memchr v2.5.0
    Checking bstr v1.4.0 (/Users/lopopolo/dev/repos/bstr)
warning: associated function `new` is never used
   --> src/escape_bytes.rs:138:19
    |
138 |     pub(crate) fn new<T: IntoIterator<IntoIter = I>>(
    |                   ^^^
    |
    = note: `#[warn(dead_code)]` on by default

warning: `bstr` (lib) generated 1 warning
    Finished dev [unoptimized + debuginfo] target(s) in 1.08s
```

This commit gates `UnescapeBytes` and its supporting impl blocks, enums and free functions behind `#[cfg(feature = "alloc")]`. This frees no default features users from paying the compile cost of this unreachable code.

I've tweaked the CI job definition to add `-D warnings` to `RUSTFLAGS` to ensure `bstr` builds without warnings in all tested configurations, but I can back that out if you'd like.