### PR TITLE
Address clippy lints

### DIFF
--- a/src/ascii.rs
+++ b/src/ascii.rs
@@ -238,8 +238,7 @@ unsafe fn ptr_add(ptr: *const u8, amt: usize) -> *const u8 {
 
 /// Decrement the given pointer by the given amount.
 unsafe fn ptr_sub(ptr: *const u8, amt: usize) -> *const u8 {
-    debug_assert!(amt < ::core::isize::MAX as usize);
-    ptr.offset((amt as isize).wrapping_neg())
+    ptr.sub(amt)
 }
 
 #[cfg(any(test, miri, not(target_arch = "x86_64")))]

--- a/src/ascii.rs
+++ b/src/ascii.rs
@@ -233,8 +233,7 @@ fn first_non_ascii_byte_mask(mask: usize) -> usize {
 
 /// Increment the given pointer by the given amount.
 unsafe fn ptr_add(ptr: *const u8, amt: usize) -> *const u8 {
-    debug_assert!(amt < ::core::isize::MAX as usize);
-    ptr.offset(amt as isize)
+    ptr.add(amt)
 }
 
 /// Decrement the given pointer by the given amount.

--- a/src/bstr.rs
+++ b/src/bstr.rs
@@ -1,5 +1,3 @@
-use core::mem;
-
 #[cfg(feature = "alloc")]
 use alloc::boxed::Box;
 
@@ -72,12 +70,12 @@ impl BStr {
 
     #[inline]
     pub(crate) fn from_bytes(slice: &[u8]) -> &BStr {
-        unsafe { mem::transmute(slice) }
+        unsafe { &*(slice as *const [u8] as *const BStr) }
     }
 
     #[inline]
     pub(crate) fn from_bytes_mut(slice: &mut [u8]) -> &mut BStr {
-        unsafe { mem::transmute(slice) }
+        unsafe { &mut *(slice as *mut [u8] as *mut BStr) }
     }
 
     #[inline]

--- a/src/bstr.rs
+++ b/src/bstr.rs
@@ -29,7 +29,6 @@ use alloc::boxed::Box;
 /// The `Display` implementation behaves as if `BStr` were first lossily
 /// converted to a `str`. Invalid UTF-8 bytes are substituted with the Unicode
 /// replacement codepoint, which looks like this: �.
-#[derive(Hash)]
 #[repr(transparent)]
 pub struct BStr {
     pub(crate) bytes: [u8],

--- a/src/bstr.rs
+++ b/src/bstr.rs
@@ -60,7 +60,7 @@ impl BStr {
     /// assert_eq!(a, c);
     /// ```
     #[inline]
-    pub fn new<'a, B: ?Sized + AsRef<[u8]>>(bytes: &'a B) -> &'a BStr {
+    pub fn new<B: ?Sized + AsRef<[u8]>>(bytes: &B) -> &BStr {
         BStr::from_bytes(bytes.as_ref())
     }
 

--- a/src/bstring.rs
+++ b/src/bstring.rs
@@ -38,7 +38,7 @@ use crate::bstr::BStr;
 /// A `BString` has the same representation as a `Vec<u8>` and a `String`.
 /// That is, it is made up of three word sized components: a pointer to a
 /// region of memory containing the bytes, a length and a capacity.
-#[derive(Clone, Hash)]
+#[derive(Clone)]
 pub struct BString {
     bytes: Vec<u8>,
 }

--- a/src/byteset/mod.rs
+++ b/src/byteset/mod.rs
@@ -14,7 +14,7 @@ fn build_table(byteset: &[u8]) -> [u8; 256] {
 #[inline]
 pub(crate) fn find(haystack: &[u8], byteset: &[u8]) -> Option<usize> {
     match byteset.len() {
-        0 => return None,
+        0 => None,
         1 => memchr(byteset[0], haystack),
         2 => memchr2(byteset[0], byteset[1], haystack),
         3 => memchr3(byteset[0], byteset[1], byteset[2], haystack),
@@ -28,7 +28,7 @@ pub(crate) fn find(haystack: &[u8], byteset: &[u8]) -> Option<usize> {
 #[inline]
 pub(crate) fn rfind(haystack: &[u8], byteset: &[u8]) -> Option<usize> {
     match byteset.len() {
-        0 => return None,
+        0 => None,
         1 => memrchr(byteset[0], haystack),
         2 => memrchr2(byteset[0], byteset[1], haystack),
         3 => memrchr3(byteset[0], byteset[1], byteset[2], haystack),
@@ -45,7 +45,7 @@ pub(crate) fn find_not(haystack: &[u8], byteset: &[u8]) -> Option<usize> {
         return None;
     }
     match byteset.len() {
-        0 => return Some(0),
+        0 => Some(0),
         1 => scalar::inv_memchr(byteset[0], haystack),
         2 => scalar::forward_search_bytes(haystack, |b| {
             b != byteset[0] && b != byteset[1]
@@ -65,7 +65,7 @@ pub(crate) fn rfind_not(haystack: &[u8], byteset: &[u8]) -> Option<usize> {
         return None;
     }
     match byteset.len() {
-        0 => return Some(haystack.len() - 1),
+        0 => Some(haystack.len() - 1),
         1 => scalar::inv_memrchr(byteset[0], haystack),
         2 => scalar::reverse_search_bytes(haystack, |b| {
             b != byteset[0] && b != byteset[1]

--- a/src/byteset/scalar.rs
+++ b/src/byteset/scalar.rs
@@ -84,7 +84,7 @@ pub fn inv_memrchr(n1: u8, haystack: &[u8]) -> Option<usize> {
             debug_assert_eq!(0, (ptr as usize) % USIZE_BYTES);
 
             let a = *(ptr.sub(2 * USIZE_BYTES) as *const usize);
-            let b = *(ptr.sub(1 * USIZE_BYTES) as *const usize);
+            let b = *(ptr.sub(USIZE_BYTES) as *const usize);
             let eqa = (a ^ vn1) != 0;
             let eqb = (b ^ vn1) != 0;
             if eqa || eqb {

--- a/src/ext_slice.rs
+++ b/src/ext_slice.rs
@@ -3374,7 +3374,7 @@ pub struct Fields<'a> {
 #[cfg(feature = "unicode")]
 impl<'a> Fields<'a> {
     fn new(bytes: &'a [u8]) -> Fields<'a> {
-        Fields { it: bytes.fields_with(|ch| ch.is_whitespace()) }
+        Fields { it: bytes.fields_with(char::is_whitespace) }
     }
 }
 

--- a/src/ext_slice.rs
+++ b/src/ext_slice.rs
@@ -72,7 +72,7 @@ use crate::{
 /// string literals. This can be quite convenient!
 #[allow(non_snake_case)]
 #[inline]
-pub fn B<'a, B: ?Sized + AsRef<[u8]>>(bytes: &'a B) -> &'a [u8] {
+pub fn B<B: ?Sized + AsRef<[u8]>>(bytes: &B) -> &[u8] {
     bytes.as_ref()
 }
 

--- a/src/ext_slice.rs
+++ b/src/ext_slice.rs
@@ -3045,7 +3045,7 @@ pub trait ByteSlice: private::Sealed {
     #[inline]
     fn last_byte(&self) -> Option<u8> {
         let bytes = self.as_bytes();
-        bytes.get(bytes.len().saturating_sub(1)).copied()
+        bytes.last().copied()
     }
 
     /// Returns the index of the first non-ASCII byte in this byte string (if

--- a/src/ext_slice.rs
+++ b/src/ext_slice.rs
@@ -3428,7 +3428,7 @@ impl<'a, F: FnMut(char) -> bool> Iterator for FieldsWith<'a, F> {
                 }
             }
         }
-        while let Some((_, e, ch)) = self.chars.next() {
+        for (_, e, ch) in self.chars.by_ref() {
             if (self.f)(ch) {
                 break;
             }

--- a/src/ext_slice.rs
+++ b/src/ext_slice.rs
@@ -3744,7 +3744,7 @@ impl<'a> Iterator for LinesWithTerminator<'a> {
                 Some(line)
             }
             Some(end) => {
-                let line = &self.bytes[..end + 1];
+                let line = &self.bytes[..=end];
                 self.bytes = &self.bytes[end + 1..];
                 Some(line)
             }
@@ -3764,7 +3764,7 @@ impl<'a> DoubleEndedIterator for LinesWithTerminator<'a> {
             }
             Some(end) => {
                 let line = &self.bytes[end + 1..];
-                self.bytes = &self.bytes[..end + 1];
+                self.bytes = &self.bytes[..=end];
                 Some(line)
             }
         }

--- a/src/ext_slice.rs
+++ b/src/ext_slice.rs
@@ -3045,7 +3045,7 @@ pub trait ByteSlice: private::Sealed {
     #[inline]
     fn last_byte(&self) -> Option<u8> {
         let bytes = self.as_bytes();
-        bytes.get(bytes.len().saturating_sub(1)).map(|&b| b)
+        bytes.get(bytes.len().saturating_sub(1)).copied()
     }
 
     /// Returns the index of the first non-ASCII byte in this byte string (if
@@ -3331,7 +3331,7 @@ impl<'a> Iterator for Bytes<'a> {
 
     #[inline]
     fn next(&mut self) -> Option<u8> {
-        self.it.next().map(|&b| b)
+        self.it.next().copied()
     }
 
     #[inline]
@@ -3343,7 +3343,7 @@ impl<'a> Iterator for Bytes<'a> {
 impl<'a> DoubleEndedIterator for Bytes<'a> {
     #[inline]
     fn next_back(&mut self) -> Option<u8> {
-        self.it.next_back().map(|&b| b)
+        self.it.next_back().copied()
     }
 }
 

--- a/src/ext_vec.rs
+++ b/src/ext_vec.rs
@@ -223,10 +223,10 @@ pub trait ByteVec: private::Sealed {
     /// ```
     #[inline]
     #[cfg(feature = "std")]
-    fn from_os_str_lossy<'a>(os_str: &'a OsStr) -> Cow<'a, [u8]> {
+    fn from_os_str_lossy(os_str: &OsStr) -> Cow<'_, [u8]> {
         #[cfg(unix)]
         #[inline]
-        fn imp<'a>(os_str: &'a OsStr) -> Cow<'a, [u8]> {
+        fn imp(os_str: &OsStr) -> Cow<'_, [u8]> {
             use std::os::unix::ffi::OsStrExt;
 
             Cow::Borrowed(os_str.as_bytes())
@@ -234,7 +234,7 @@ pub trait ByteVec: private::Sealed {
 
         #[cfg(not(unix))]
         #[inline]
-        fn imp<'a>(os_str: &'a OsStr) -> Cow<'a, [u8]> {
+        fn imp(os_str: &OsStr) -> Cow<'_, [u8]> {
             match os_str.to_string_lossy() {
                 Cow::Borrowed(x) => Cow::Borrowed(x.as_bytes()),
                 Cow::Owned(x) => Cow::Owned(Vec::from(x)),
@@ -292,7 +292,7 @@ pub trait ByteVec: private::Sealed {
     /// ```
     #[inline]
     #[cfg(feature = "std")]
-    fn from_path_lossy<'a>(path: &'a Path) -> Cow<'a, [u8]> {
+    fn from_path_lossy(path: &Path) -> Cow<'_, [u8]> {
         Vec::from_os_str_lossy(path.as_os_str())
     }
 

--- a/src/ext_vec.rs
+++ b/src/ext_vec.rs
@@ -961,7 +961,7 @@ pub trait ByteVec: private::Sealed {
         R: ops::RangeBounds<usize>,
         B: AsRef<[u8]>,
     {
-        self.as_vec_mut().splice(range, replace_with.as_ref().iter().cloned());
+        self.as_vec_mut().splice(range, replace_with.as_ref().iter().copied());
     }
 
     /// Creates a draining iterator that removes the specified range in this

--- a/src/ext_vec.rs
+++ b/src/ext_vec.rs
@@ -188,7 +188,7 @@ pub trait ByteVec: private::Sealed {
         fn imp(os_str: OsString) -> Result<Vec<u8>, OsString> {
             use std::os::unix::ffi::OsStringExt;
 
-            Ok(Vec::from(os_str.into_vec()))
+            Ok(os_str.into_vec())
         }
 
         #[cfg(not(unix))]

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -342,7 +342,7 @@ mod bstring {
     impl PartialEq for BString {
         #[inline]
         fn eq(&self, other: &BString) -> bool {
-            &self[..] == &other[..]
+            self[..] == other[..]
         }
     }
 

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -486,7 +486,10 @@ mod bstr {
                     | '\x7f' => {
                         write!(f, "\\x{:02x}", ch as u32)?;
                     }
-                    '\n' | '\r' | '\t' | _ => {
+                    '\n' | '\r' | '\t' => {
+                        write!(f, "{}", ch.escape_debug())?;
+                    }
+                    _ => {
                         write!(f, "{}", ch.escape_debug())?;
                     }
                 }

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -62,7 +62,7 @@ macro_rules! impl_partial_ord {
 #[cfg(feature = "alloc")]
 mod bstring {
     use core::{
-        cmp::Ordering, convert::TryFrom, fmt, iter::FromIterator, ops,
+        cmp::Ordering, convert::TryFrom, fmt, hash, iter::FromIterator, ops,
     };
 
     use alloc::{
@@ -355,6 +355,13 @@ mod bstring {
     impl_partial_eq!(BString, BStr);
     impl_partial_eq!(BString, &'a BStr);
 
+    impl hash::Hash for BString {
+        #[inline]
+        fn hash<H: hash::Hasher>(&self, state: &mut H) {
+            self.as_bytes().hash(state);
+        }
+    }
+
     impl PartialOrd for BString {
         #[inline]
         fn partial_cmp(&self, other: &BString) -> Option<Ordering> {
@@ -384,7 +391,7 @@ mod bstr {
         borrow::{Borrow, BorrowMut},
         cmp::Ordering,
         convert::TryFrom,
-        fmt, ops,
+        fmt, hash, ops,
     };
 
     #[cfg(feature = "alloc")]
@@ -813,6 +820,13 @@ mod bstr {
     impl_partial_eq_cow!(&'a BStr, Cow<'a, str>);
     #[cfg(feature = "alloc")]
     impl_partial_eq_cow!(&'a BStr, Cow<'a, [u8]>);
+
+    impl hash::Hash for BStr {
+        #[inline]
+        fn hash<H: hash::Hasher>(&self, state: &mut H) {
+            self.as_bytes().hash(state);
+        }
+    }
 
     impl PartialOrd for BStr {
         #[inline]

--- a/src/io.rs
+++ b/src/io.rs
@@ -142,7 +142,7 @@ pub trait BufReadExt: io::BufRead {
         F: FnMut(&[u8]) -> io::Result<bool>,
     {
         self.for_byte_line_with_terminator(|line| {
-            for_each_line(&trim_line_slice(&line))
+            for_each_line(trim_line_slice(line))
         })
     }
 
@@ -193,7 +193,7 @@ pub trait BufReadExt: io::BufRead {
         F: FnMut(&[u8]) -> io::Result<bool>,
     {
         self.for_byte_record_with_terminator(terminator, |chunk| {
-            for_each_record(&trim_record_slice(&chunk, terminator))
+            for_each_record(trim_record_slice(chunk, terminator))
         })
     }
 
@@ -306,7 +306,7 @@ pub trait BufReadExt: io::BufRead {
                     let (record, rest) = buf.split_at(index + 1);
                     buf = rest;
                     consumed += record.len();
-                    match for_each_record(&record) {
+                    match for_each_record(record) {
                         Ok(false) => break 'outer,
                         Err(err) => {
                             res = Err(err);
@@ -319,7 +319,7 @@ pub trait BufReadExt: io::BufRead {
                 // Copy the final record fragment to our local buffer. This
                 // saves read_until() from re-scanning a buffer we know
                 // contains no remaining terminators.
-                bytes.extend_from_slice(&buf);
+                bytes.extend_from_slice(buf);
                 consumed += buf.len();
             }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::single_char_add_str)]
+
 /*!
 A byte string library.
 

--- a/src/unicode/fsm/mod.rs
+++ b/src/unicode/fsm/mod.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::all)]
+
 pub mod grapheme_break_fwd;
 pub mod grapheme_break_rev;
 pub mod regional_indicator_rev;

--- a/src/unicode/grapheme.rs
+++ b/src/unicode/grapheme.rs
@@ -216,7 +216,7 @@ pub fn decode_grapheme(bs: &[u8]) -> (&str, usize) {
         let grapheme = unsafe { bs[..end].to_str_unchecked() };
         (grapheme, grapheme.len())
     } else {
-        const INVALID: &'static str = "\u{FFFD}";
+        const INVALID: &str = "\u{FFFD}";
         // No match on non-empty bytes implies we found invalid UTF-8.
         let (_, size) = utf8::decode_lossy(bs);
         (INVALID, size)
@@ -232,7 +232,7 @@ fn decode_last_grapheme(bs: &[u8]) -> (&str, usize) {
         let grapheme = unsafe { bs[start..].to_str_unchecked() };
         (grapheme, grapheme.len())
     } else {
-        const INVALID: &'static str = "\u{FFFD}";
+        const INVALID: &str = "\u{FFFD}";
         // No match on non-empty bytes implies we found invalid UTF-8.
         let (_, size) = utf8::decode_last_lossy(bs);
         (INVALID, size)
@@ -365,8 +365,7 @@ mod tests {
     /// Return all of the UCD for grapheme breaks.
     #[cfg(not(miri))]
     fn ucdtests() -> Vec<GraphemeClusterBreakTest> {
-        const TESTDATA: &'static str =
-            include_str!("data/GraphemeBreakTest.txt");
+        const TESTDATA: &str = include_str!("data/GraphemeBreakTest.txt");
 
         let mut tests = vec![];
         for mut line in TESTDATA.lines() {

--- a/src/unicode/sentence.rs
+++ b/src/unicode/sentence.rs
@@ -150,7 +150,7 @@ fn decode_sentence(bs: &[u8]) -> (&str, usize) {
         let sentence = unsafe { bs[..end].to_str_unchecked() };
         (sentence, sentence.len())
     } else {
-        const INVALID: &'static str = "\u{FFFD}";
+        const INVALID: &str = "\u{FFFD}";
         // No match on non-empty bytes implies we found invalid UTF-8.
         let (_, size) = utf8::decode_lossy(bs);
         (INVALID, size)
@@ -209,8 +209,7 @@ mod tests {
     /// Return all of the UCD for sentence breaks.
     #[cfg(not(miri))]
     fn ucdtests() -> Vec<SentenceBreakTest> {
-        const TESTDATA: &'static str =
-            include_str!("data/SentenceBreakTest.txt");
+        const TESTDATA: &str = include_str!("data/SentenceBreakTest.txt");
 
         let mut tests = vec![];
         for mut line in TESTDATA.lines() {

--- a/src/unicode/word.rs
+++ b/src/unicode/word.rs
@@ -66,7 +66,7 @@ impl<'a> Iterator for Words<'a> {
 
     #[inline]
     fn next(&mut self) -> Option<&'a str> {
-        while let Some(word) = self.0.next() {
+        for word in self.0.by_ref() {
             if SIMPLE_WORD_FWD.is_match(word.as_bytes()) {
                 return Some(word);
             }
@@ -142,7 +142,7 @@ impl<'a> Iterator for WordIndices<'a> {
 
     #[inline]
     fn next(&mut self) -> Option<(usize, usize, &'a str)> {
-        while let Some((start, end, word)) = self.0.next() {
+        for (start, end, word) in self.0.by_ref() {
             if SIMPLE_WORD_FWD.is_match(word.as_bytes()) {
                 return Some((start, end, word));
             }

--- a/src/unicode/word.rs
+++ b/src/unicode/word.rs
@@ -312,7 +312,7 @@ fn decode_word(bs: &[u8]) -> (&str, usize) {
         let word = unsafe { bs[..end].to_str_unchecked() };
         (word, word.len())
     } else {
-        const INVALID: &'static str = "\u{FFFD}";
+        const INVALID: &str = "\u{FFFD}";
         // No match on non-empty bytes implies we found invalid UTF-8.
         let (_, size) = utf8::decode_lossy(bs);
         (INVALID, size)
@@ -405,7 +405,7 @@ mod tests {
     /// Return all of the UCD for word breaks.
     #[cfg(not(miri))]
     fn ucdtests() -> Vec<WordBreakTest> {
-        const TESTDATA: &'static str = include_str!("data/WordBreakTest.txt");
+        const TESTDATA: &str = include_str!("data/WordBreakTest.txt");
 
         let mut tests = vec![];
         for mut line in TESTDATA.lines() {

--- a/src/unicode/word.rs
+++ b/src/unicode/word.rs
@@ -66,12 +66,7 @@ impl<'a> Iterator for Words<'a> {
 
     #[inline]
     fn next(&mut self) -> Option<&'a str> {
-        for word in self.0.by_ref() {
-            if SIMPLE_WORD_FWD.is_match(word.as_bytes()) {
-                return Some(word);
-            }
-        }
-        None
+        self.0.by_ref().find(|&word| SIMPLE_WORD_FWD.is_match(word.as_bytes()))
     }
 }
 

--- a/src/utf8.rs
+++ b/src/utf8.rs
@@ -55,7 +55,7 @@ const CLASSES: [u8; 256] = [
 /// SAFETY: The decode below function relies on the correctness of this state
 /// machine.
 #[rustfmt::skip]
-const STATES_FORWARD: &'static [u8] = &[
+const STATES_FORWARD: &[u8] = &[
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
   12, 0, 24, 36, 60, 96, 84, 0, 0, 0, 48, 72,
   0, 12, 0, 0, 0, 0, 0, 12, 0, 12, 0, 0,

--- a/src/utf8.rs
+++ b/src/utf8.rs
@@ -816,10 +816,11 @@ pub fn decode_last_lossy<B: AsRef<[u8]>>(slice: B) -> (char, usize) {
 #[inline]
 pub fn decode_step(state: &mut usize, cp: &mut u32, b: u8) {
     let class = CLASSES[b as usize];
+    let b = u32::from(b);
     if *state == ACCEPT {
-        *cp = (0xFF >> class) & (b as u32);
+        *cp = (0xFF >> class) & b;
     } else {
-        *cp = (b as u32 & 0b111111) | (*cp << 6);
+        *cp = (b & 0b0011_1111) | (*cp << 6);
     }
     *state = STATES_FORWARD[*state + class as usize] as usize;
 }

--- a/src/utf8.rs
+++ b/src/utf8.rs
@@ -608,7 +608,7 @@ pub fn validate(slice: &[u8]) -> Result<(), Utf8Error> {
 #[inline]
 pub fn decode<B: AsRef<[u8]>>(slice: B) -> (Option<char>, usize) {
     let slice = slice.as_ref();
-    match slice.get(0) {
+    match slice.first() {
         None => return (None, 0),
         Some(&b) if b <= 0x7F => return (Some(b as char), 1),
         _ => {}

--- a/src/utf8.rs
+++ b/src/utf8.rs
@@ -40,7 +40,7 @@ const REJECT: usize = 0;
 
 /// SAFETY: The decode below function relies on the correctness of these
 /// equivalence classes.
-#[cfg_attr(rustfmt, rustfmt::skip)]
+#[rustfmt::skip]
 const CLASSES: [u8; 256] = [
    0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,  0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
    0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,  0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
@@ -54,7 +54,7 @@ const CLASSES: [u8; 256] = [
 
 /// SAFETY: The decode below function relies on the correctness of this state
 /// machine.
-#[cfg_attr(rustfmt, rustfmt::skip)]
+#[rustfmt::skip]
 const STATES_FORWARD: &'static [u8] = &[
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
   12, 0, 24, 36, 60, 96, 84, 0, 0, 0, 48, 72,


### PR DESCRIPTION
This PR addresses clippy lint violations, one violation at a time, by working through `cargo clippy` output. This uses the default warn set of warnings in clippy.

I did run `cargo clippy --fix -- --warn clippy::pedantic` to see what it would do and it converted a lot of pointer `as` casts to `ptr.cast::<_>()` calls. I find this increases readability and is less footgun-y in that it preserves the constness of pointers, but I did not include these changes in this PR.

I did not include any changes to the CI pipeline in this PR.

See #158.