### PR TITLE
`impl<'a> From<&'a BString> for Cow<'a, BStr>`

### DIFF
--- a/src/impls.rs
+++ b/src/impls.rs
@@ -268,6 +268,13 @@ mod bstring {
         }
     }
 
+    impl<'a> From<&'a BString> for Cow<'a, BStr> {
+        #[inline]
+        fn from(s: &'a BString) -> Cow<'a, BStr> {
+            Cow::Borrowed(s.as_bstr())
+        }
+    }
+
     impl TryFrom<BString> for String {
         type Error = crate::FromUtf8Error;
 


### PR DESCRIPTION
This commit simplifies code in situations like:

```
let mut v = Vec::<Cow<'a, BStr>>::new();
let s = BString::new(...);

// Before this commit, we would have to do:
// v.push(s.as_bstr().into());
v.push(s.into());
```