### PR TITLE
Fix elided_named_lifetimes warning on nightly (fixing CI)

### DIFF
--- a/src/escape_bytes.rs
+++ b/src/escape_bytes.rs
@@ -12,7 +12,7 @@ pub struct EscapeBytes<'a> {
 }
 
 impl<'a> EscapeBytes<'a> {
-    pub(crate) fn new(bytes: &'a [u8]) -> EscapeBytes {
+    pub(crate) fn new(bytes: &'a [u8]) -> Self {
         EscapeBytes { remaining: bytes, state: EscapeState::Start }
     }
 }


### PR DESCRIPTION
A build on nightly currently produces this:

```
warning: elided lifetime has a name
  --> src/escape_bytes.rs:15:43
   |
14 | impl<'a> EscapeBytes<'a> {
   |      -- lifetime `'a` declared here
15 |     pub(crate) fn new(bytes: &'a [u8]) -> EscapeBytes {
   |                                           ^^^^^^^^^^^ this elided lifetime gets resolved as `'a`
   |
   = note: `#[warn(elided_named_lifetimes)]` on by default
```

Fix that by changing `EscapeBytes` to `Self`, which constrains the
lifetime.
