### PR TITLE
Fix `impl_partial_eq_cow` to apply `.as_bytes()` and `&**` to the correct arguments

### DIFF
--- a/src/impls.rs
+++ b/src/impls.rs
@@ -52,8 +52,8 @@ macro_rules! impl_partial_eq_cow {
         impl<'a> PartialEq<$lhs> for $rhs {
             #[inline]
             fn eq(&self, other: &$lhs) -> bool {
-                let this: &[u8] = (&**other).as_ref();
-                PartialEq::eq(this, self.as_bytes())
+                let this: &[u8] = (&**self).as_ref();
+                PartialEq::eq(this, other.as_bytes())
             }
         }
     };


### PR DESCRIPTION
`impl_partial_eq_cow`, in its second trail impl, had the arguments the
wrong way around, applying `&**` to the ByteStr argument and
`.as_bytes()` to the `Cow`.

Fix it to use the same structure as `impl_partial_eq`.
