### PR TITLE
fix: generate-unicode-data

### DIFF
--- a/scripts/generate-unicode-data
+++ b/scripts/generate-unicode-data
@@ -45,7 +45,7 @@ graphemes() {
       --start-kind anchored \
       --reverse \
       --match-kind all \
-      --no-captures \
+      --captures none \
       --shrink \
       --rustfmt \
       --safe \
@@ -93,7 +93,7 @@ regional_indicator() {
       --minimize \
       --start-kind anchored \
       --reverse \
-      --no-captures \
+      --captures none \
       --shrink \
       --rustfmt \
       --safe \
@@ -132,7 +132,7 @@ whitespace() {
       --minimize \
       --start-kind anchored \
       --reverse \
-      --no-captures \
+      --captures none \
       --shrink \
       --rustfmt \
       --safe \


### PR DESCRIPTION
Moves from --no-captures flag -> --captures none, as introduced in https://github.com/rust-lang/regex/commit/662a8b93afa55b5c489f14bca83565ebe62ccf67