### PR TITLE
lint: add set -u to regex scripts

### DIFF
--- a/scripts/regex/grapheme.sh
+++ b/scripts/regex/grapheme.sh
@@ -6,6 +6,9 @@
 # This regex was manually written, derived from the rules in UAX #29.
 # Particularly, from Table 1c, which lays out a regex for grapheme clusters.
 
+# Abort on undefined variables
+set -u
+
 CR="\p{gcb=CR}"
 LF="\p{gcb=LF}"
 Control="\p{gcb=Control}"

--- a/scripts/regex/sentence.sh
+++ b/scripts/regex/sentence.sh
@@ -91,6 +91,9 @@
 # UAX #29's recommendation in S6.2. Essentially, we use it avoid ever breaking
 # in the middle of a grapheme cluster.
 
+# Abort on undefined variables
+set -u
+
 CR="\p{sb=CR}"
 LF="\p{sb=LF}"
 Sep="\p{sb=Sep}"

--- a/scripts/regex/word.sh
+++ b/scripts/regex/word.sh
@@ -32,6 +32,9 @@
 #
 # Gah.
 
+# Abort on undefined variables
+set -u
+
 CR="\p{wb=CR}"
 LF="\p{wb=LF}"
 Newline="\p{wb=Newline}"


### PR DESCRIPTION
Will brick the script if any of the used variables are undefined. This should help prevent typos, which seem particularly nasty to debug here.