### PR TITLE
doc: switch to `doc_cfg` from `doc_auto_cfg`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ all-features = true
 # Since this crate's feature setup is pretty complicated, it is worth opting
 # into a nightly unstable option to show the features that need to be enabled
 # for public API items. To do that, we set 'docsrs', and when that's enabled,
-# we enable the 'doc_auto_cfg' feature.
+# we enable the 'doc_cfg' feature.
 #
 # To test this locally, run:
 #

--- a/src/ext_slice.rs
+++ b/src/ext_slice.rs
@@ -2783,11 +2783,11 @@ pub trait ByteSlice: private::Sealed {
     /// The dual of this function is [`ByteVec::unescape_bytes`].
     ///
     /// Note that this is similar to, but not equivalent to the `Debug`
-    /// implementation on [`BStr`] and [`BString`]. The `Debug` implementations
-    /// also use the debug representation for all Unicode codepoints. However,
-    /// this escaping routine only escapes individual bytes. All Unicode
-    /// codepoints above `U+007F` are passed through unchanged without any
-    /// escaping.
+    /// implementation on [`BStr`] and [`BString`](crate::BString). The `Debug`
+    /// implementations also use the debug representation for all Unicode
+    /// codepoints. However, this escaping routine only escapes individual
+    /// bytes. All Unicode codepoints above `U+007F` are passed through
+    /// unchanged without any escaping.
     ///
     /// # Examples
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -393,7 +393,7 @@ and Unicode support.
 
 // #![cfg_attr(not(any(feature = "std", test)), no_std)]
 #![no_std]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 #[cfg(any(test, feature = "std"))]
 extern crate std;


### PR DESCRIPTION
This feature was renamed. Hopefully it will be stabilized soon.

Fixes #217
