### PR TITLE
Switch serde dependency to serde_core

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,14 +23,14 @@ bench = false
 
 [features]
 default = ["std", "unicode"]
-std = ["alloc", "memchr/std", "serde?/std"]
-alloc = ["memchr/alloc", "serde?/alloc"]
+std = ["alloc", "memchr/std", "serde_core?/std"]
+alloc = ["memchr/alloc", "serde_core?/alloc"]
 unicode = ["dep:regex-automata"]
-serde = ["dep:serde"]
+serde = ["dep:serde_core"]
 
 [dependencies]
 memchr = { version = "2.7.1", default-features = false }
-serde = { version = "1.0.85", default-features = false, optional = true }
+serde_core = { version = "1.0.85", default-features = false, optional = true }
 
 [dependencies.regex-automata]
 version = "0.4.1"

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -925,7 +925,7 @@ mod bstr {
 mod bstr_serde {
     use core::fmt;
 
-    use serde::{
+    use serde_core::{
         de::Error, de::Visitor, Deserialize, Deserializer, Serialize,
         Serializer,
     };
@@ -985,7 +985,7 @@ mod bstring_serde {
 
     use alloc::{boxed::Box, string::String, vec::Vec};
 
-    use serde::{
+    use serde_core::{
         de::Error, de::SeqAccess, de::Visitor, Deserialize, Deserializer,
         Serialize, Serializer,
     };


### PR DESCRIPTION
Since this crate doesn't use serde_derive, depending on serde_core enables it to be compiled in parallel to serde_derive.