### PR TITLE
Add `#[must_use]` to `ByteSlice::replace[n]`

### DIFF
--- a/src/ext_slice.rs
+++ b/src/ext_slice.rs
@@ -1542,6 +1542,7 @@ pub trait ByteSlice: private::Sealed {
     /// assert_eq!(s, "ZfZoZoZ".as_bytes());
     /// ```
     #[cfg(feature = "alloc")]
+    #[must_use]
     #[inline]
     fn replace<N: AsRef<[u8]>, R: AsRef<[u8]>>(
         &self,
@@ -1588,6 +1589,7 @@ pub trait ByteSlice: private::Sealed {
     /// assert_eq!(s, "ZfZoo".as_bytes());
     /// ```
     #[cfg(feature = "alloc")]
+    #[must_use]
     #[inline]
     fn replacen<N: AsRef<[u8]>, R: AsRef<[u8]>>(
         &self,


### PR DESCRIPTION
The attribute is stable since Rust 1.27, which is way earlier than the rust-version in `Cargo.toml`. The `str` methods in std also have that attribute, as it's a common pitfall.