### PR TITLE
Implement `Iterator::count` for `Chars`

### DIFF
--- a/bench/src/bench.rs
+++ b/bench/src/bench.rs
@@ -164,6 +164,26 @@ fn chars(c: &mut Criterion) {
     }
 }
 
+fn chars_count(c: &mut Criterion) {
+    // benchmark our impl
+    for &(name, corpus) in CORPORA_HUGE {
+        define(c, "bstr/chars_count", name, corpus, move |b| {
+            b.iter(|| {
+                assert!(corpus.chars().count() > 0);
+            });
+        });
+    }
+    // benchmark std's impl
+    for &(name, corpus) in CORPORA_HUGE {
+        define(c, "std/chars_count", name, corpus, move |b| {
+            let corpus = std::str::from_utf8(corpus).unwrap();
+            b.iter(|| {
+                assert!(corpus.chars().count() > 0);
+            });
+        });
+    }
+}
+
 fn graphemes(c: &mut Criterion) {
     // benchmark our impl
     for &(name, corpus) in CORPORA_SMALL {
@@ -287,4 +307,7 @@ criterion_group!(g11, search::rfind_iter);
 criterion_group!(g12, search::find_char);
 criterion_group!(g13, search::find_byteset);
 criterion_group!(g14, search::find_not_byteset);
-criterion_main!(g1, g2, g3, g4, g5, g6, g7, g8, g9, g10, g11, g12, g13, g14);
+criterion_group!(g15, chars_count);
+criterion_main!(
+    g1, g2, g3, g4, g5, g6, g7, g8, g9, g10, g11, g12, g13, g14, g15
+);

--- a/src/utf8.rs
+++ b/src/utf8.rs
@@ -125,10 +125,15 @@ impl<'a> Iterator for Chars<'a> {
     fn count(mut self) -> usize {
         let mut count = 0;
         loop {
-            // ASCII fast path.
-            let size = ascii::first_non_ascii_byte(self.bs);
-            count += size;
-            self.bs = &self.bs[size..];
+            // ASCII fast path taken if two consecutive ASCII chars found
+            match self.bs {
+                [fst, snd, ..] if *fst <= 0x7F && *snd <= 0x7F => {
+                    let size = ascii::first_non_ascii_byte(self.bs);
+                    count += size;
+                    self.bs = &self.bs[size..];
+                }
+                _ => (),
+            }
 
             let (_ch, size) = decode(self.bs);
             if size == 0 {

--- a/src/utf8.rs
+++ b/src/utf8.rs
@@ -120,6 +120,25 @@ impl<'a> Iterator for Chars<'a> {
         self.bs = &self.bs[size..];
         Some(ch)
     }
+
+    #[inline]
+    fn count(mut self) -> usize {
+        let mut count = 0;
+        loop {
+            // ASCII fast path.
+            let size = ascii::first_non_ascii_byte(self.bs);
+            count += size;
+            self.bs = &self.bs[size..];
+
+            let (_ch, size) = decode(self.bs);
+            if size == 0 {
+                return count;
+            } else {
+                count += 1;
+                self.bs = &self.bs[size..];
+            }
+        }
+    }
 }
 
 impl<'a> DoubleEndedIterator for Chars<'a> {

--- a/src/utf8.rs
+++ b/src/utf8.rs
@@ -1271,7 +1271,7 @@ mod tests {
             assert_eq!(
                 B(input).chars().collect::<Vec<char>>().len(),
                 B(input).chars().count(),
-                "chars.len(ith: {:?}, given: {:?})",
+                "chars.count(ith: {:?}, given: {:?})",
                 i,
                 input
             );

--- a/src/utf8.rs
+++ b/src/utf8.rs
@@ -1268,6 +1268,14 @@ mod tests {
     #[test]
     fn chars() {
         for (i, &(expected, input)) in LOSSY_TESTS.iter().enumerate() {
+            assert_eq!(
+                B(input).chars().collect::<Vec<char>>().len(),
+                B(input).chars().count(),
+                "chars.len(ith: {:?}, given: {:?})",
+                i,
+                input
+            );
+
             let got: String = B(input).chars().collect();
             assert_eq!(
                 expected, got,


### PR DESCRIPTION
This adds a fast path for ASCII characters when counting characters, addressing https://github.com/BurntSushi/bstr/issues/221.

I added a Criterion benchmark, but I found it too complex and slow to evaluate. I therefore used the following mini-benchmark:

~~~ rust
use bstr::ByteSlice;

fn len_std(b: &str) -> usize {
    b.chars().count()
}

fn len_bstr(b: &str) -> usize {
    b.as_bytes().chars().count()
}

fn main() {
    const ITERS: usize = 50_000;
    let mut s = String::new();
    let mut len: fn(&str) -> usize = len_std;
    let mut add = "a";
    for arg in std::env::args().skip(1) {
        match &*arg {
            "std" => len = len_std,
            "bstr" => len = len_bstr,
            // pure ASCII corpus
            "ascii" => add = "a",
            // small Russian corpus (Ray Milland)
            "ru" => add = "Рэй МИЛЛАНД, Энтони КУ",
            _ => panic!(),
        }
    }
    while len(&s) < ITERS {
        s.push_str(add);
    }
}
~~~

The benchmark results in a nutshell:

- In the best case (ASCII), this PR *decreases* runtime by a factor of 698.9 ms / 19.5 ms = **35.7x**.
We have even better performance than std now in the pure-ASCII case! :)
- In the worst case (non-ASCII), this PR *increases* runtime by 125.1 ms / 92.1 ms = **1.35x**.

# Detailed Results

Before this PR:

~~~
$ hyperfine -N -w 1 -L impl bstr,std --setup "cargo build --release" "target/release/bstr-perf {impl} ascii"
Benchmark 1: target/release/bstr-perf bstr ascii
  Time (mean ± σ):     698.9 ms ±   3.6 ms    [User: 695.4 ms, System: 0.9 ms]
  Range (min … max):   693.4 ms … 704.5 ms    10 runs
 
Benchmark 2: target/release/bstr-perf std ascii
  Time (mean ± σ):      51.7 ms ±   0.9 ms    [User: 50.5 ms, System: 0.8 ms]
  Range (min … max):    50.6 ms …  55.0 ms    59 runs
 
Summary
  target/release/bstr-perf std ascii ran
   13.52 ± 0.24 times faster than target/release/bstr-perf bstr ascii

$ hyperfine -N -w 1 -L impl bstr,std --setup "cargo build --release" "target/release/bstr-perf {impl} ru"
Benchmark 1: target/release/bstr-perf bstr ru
  Time (mean ± σ):     125.1 ms ±   9.4 ms    [User: 123.5 ms, System: 1.0 ms]
  Range (min … max):   115.5 ms … 147.4 ms    23 runs
 
Benchmark 2: target/release/bstr-perf std ru
  Time (mean ± σ):       5.4 ms ±   0.5 ms    [User: 4.4 ms, System: 0.8 ms]
  Range (min … max):     4.8 ms …   7.1 ms    570 runs
 
Summary
  target/release/bstr-perf std ru ran
   23.26 ± 2.92 times faster than target/release/bstr-perf bstr ru
~~~

With this PR:

~~~
$ hyperfine -N -w 1 -L impl bstr,std --setup "cargo build --release" "target/release/bstr-perf {impl} ascii"
Benchmark 1: target/release/bstr-perf bstr ascii
  Time (mean ± σ):      19.5 ms ±   0.6 ms    [User: 18.5 ms, System: 0.8 ms]
  Range (min … max):    18.8 ms …  21.1 ms    153 runs
 
Benchmark 2: target/release/bstr-perf std ascii
  Time (mean ± σ):      51.4 ms ±   0.7 ms    [User: 50.1 ms, System: 0.8 ms]
  Range (min … max):    50.6 ms …  54.9 ms    58 runs
 
Summary
  target/release/bstr-perf bstr ascii ran
    2.63 ± 0.09 times faster than target/release/bstr-perf std ascii

$ hyperfine -N -w 1 -L impl bstr,std --setup "cargo build --release" "target/release/bstr-perf {impl} ru"
Benchmark 1: target/release/bstr-perf bstr ru
  Time (mean ± σ):      92.1 ms ±   1.6 ms    [User: 90.7 ms, System: 0.8 ms]
  Range (min … max):    90.7 ms …  99.5 ms    32 runs
 
Benchmark 2: target/release/bstr-perf std ru
  Time (mean ± σ):       5.1 ms ±   0.3 ms    [User: 4.2 ms, System: 0.6 ms]
  Range (min … max):     4.8 ms …   6.9 ms    482 runs
 
Summary
  target/release/bstr-perf std ru ran
   18.23 ± 1.14 times faster than target/release/bstr-perf bstr ru

~~~

I also tried to unconditionally run the ASCII fast path (omitting the two-consecutive-ASCII check). Results:

~~~
michi@nipogi:~/bstr-perf$ hyperfine -N -w 1 -L impl bstr,std --setup "cargo build --release" "target/release/bstr-perf {impl} ru"
Benchmark 1: target/release/bstr-perf bstr ru
  Time (mean ± σ):     180.1 ms ±   1.7 ms    [User: 178.2 ms, System: 0.8 ms]
  Range (min … max):   178.5 ms … 184.8 ms    16 runs
 
Benchmark 2: target/release/bstr-perf std ru
  Time (mean ± σ):       5.1 ms ±   0.4 ms    [User: 4.3 ms, System: 0.6 ms]
  Range (min … max):     4.8 ms …   6.9 ms    592 runs
~~~

So this takes about twice as much time than with the conditional ASCII fast path.