### PR TITLE
Decrease MSRV to 1.65

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         include:
         - build: pinned
           os: ubuntu-latest
-          rust: 1.73.0
+          rust: 1.65.0
         - build: stable
           os: ubuntu-latest
           rust: stable

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT OR Apache-2.0"
 categories = ["text-processing", "encoding"]
 exclude = ["/.github", "/scripts", "/src/unicode/data"]
 edition = "2021"
-rust-version = "1.73"
+rust-version = "1.65"
 resolver = "2"
 
 [workspace]

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Unicode support.
 
 ### Minimum Rust version policy
 
-This crate's minimum supported `rustc` version (MSRV) is `1.73`.
+This crate's minimum supported `rustc` version (MSRV) is `1.65`.
 
 In general, this crate will be conservative with respect to the minimum
 supported version of Rust. MSRV may be bumped in minor version releases.


### PR DESCRIPTION
This change would make it possible to use the current bstr version in jaq, which has an MSRV of 1.70.

`cargo test` works fine. It is not clear to me why MSRV was set to 1.73 in the first place ...