### PR TITLE
`to_bstring()`, `as_bstring()`, and `as_bstring_mut()` methods

### DIFF
--- a/src/bstring.rs
+++ b/src/bstring.rs
@@ -39,6 +39,7 @@ use crate::bstr::BStr;
 /// That is, it is made up of three word sized components: a pointer to a
 /// region of memory containing the bytes, a length and a capacity.
 #[derive(Clone)]
+#[repr(transparent)]
 pub struct BString {
     bytes: Vec<u8>,
 }
@@ -99,5 +100,23 @@ impl BString {
     #[inline]
     pub(crate) fn into_vec(self) -> Vec<u8> {
         self.bytes
+    }
+
+    #[inline]
+    pub(crate) fn from_vec_ref(v: &Vec<u8>) -> &BString {
+        // SAFETY: `BString` is a `repr(transparent)` wrapper around `Vec<u8>`, and accepts any
+        // `Vec<u8>` without validation.
+        //
+        // MSRV: Switch this to use `ptr::from_ref` once bstr can require at least Rust 1.72.
+        unsafe { &*(v as *const Vec<u8> as *const BString) }
+    }
+
+    #[inline]
+    pub(crate) fn from_vec_mut(v: &mut Vec<u8>) -> &mut BString {
+        // SAFETY: `BString` is a `repr(transparent)` wrapper around `Vec<u8>`, and accepts any
+        // `Vec<u8>` without validation.
+        //
+        // MSRV: Switch this to use `ptr::from_mut` once bstr can require at least Rust 1.72.
+        unsafe { &mut *(v as *mut Vec<u8> as *mut BString) }
     }
 }

--- a/src/ext_vec.rs
+++ b/src/ext_vec.rs
@@ -10,9 +10,9 @@ use std::{
 };
 
 use crate::{
-    BString,
     ext_slice::ByteSlice,
     utf8::{self, Utf8Error},
+    BString,
 };
 
 /// Concatenate the elements given by the iterator together into a single
@@ -169,6 +169,59 @@ pub trait ByteVec: private::Sealed {
         Self: Sized,
     {
         BString::new(self.into_vec())
+    }
+
+    /// Convert a `&Vec<u8>` to a `&BString`, without copying.
+    ///
+    /// `BString` is useful if you want its trait implementations such as `Debug`, `PartialEq`, and
+    /// `PartialOrd`, or if you want to declare at an interface boundary (field or parameter) that
+    /// something uses "conventionally UTF-8" owned strings.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// use bstr::ByteVec;
+    ///
+    /// let mut v = vec![b'a', b'b', b'c'];
+    /// let b = v.as_bstring();
+    /// println!("{b}");
+    /// assert_eq!(b, "abc");
+    /// assert_ne!(b, "hello");
+    /// // no references to `b` after this point
+    /// v.push(b'd');
+    /// assert_eq!(v, [b'a', b'b', b'c', b'd']);
+    /// ```
+    #[inline]
+    fn as_bstring(&self) -> &BString {
+        BString::from_vec_ref(self.as_vec())
+    }
+
+    /// Convert a `&mut Vec<u8>` to a `&mut BString`, without copying.
+    ///
+    /// `BString` is useful if you want its trait implementations such as `Debug`, `PartialEq`, and
+    /// `PartialOrd`, or if you want to declare at an interface boundary (field or parameter) that
+    /// something uses "conventionally UTF-8" owned strings.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// use bstr::ByteVec;
+    ///
+    /// let mut v = vec![b'a', b'b', b'c'];
+    /// let b = v.as_bstring_mut();
+    /// println!("{b}");
+    /// assert_eq!(b, "abc");
+    /// assert_ne!(b, "hello");
+    /// b.push_str("de");
+    /// assert_eq!(v, [b'a', b'b', b'c', b'd', b'e']);
+    /// ```
+    #[inline]
+    fn as_bstring_mut(&mut self) -> &mut BString {
+        BString::from_vec_mut(self.as_vec_mut())
     }
 
     /// Create a new owned byte string from the given byte slice.

--- a/src/ext_vec.rs
+++ b/src/ext_vec.rs
@@ -10,6 +10,7 @@ use std::{
 };
 
 use crate::{
+    BString,
     ext_slice::ByteSlice,
     utf8::{self, Utf8Error},
 };
@@ -140,6 +141,35 @@ pub trait ByteVec: private::Sealed {
     fn into_vec(self) -> Vec<u8>
     where
         Self: Sized;
+
+    /// Convert this type to a `BString`.
+    ///
+    /// `BString` is useful if you want its trait implementations such as `Debug`, `PartialEq`, and
+    /// `PartialOrd`, or if you want to declare at an interface boundary (field or parameter) that
+    /// something uses "conventionally UTF-8" owned strings.
+    ///
+    /// This is a zero-cost conversion.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// use bstr::ByteVec;
+    ///
+    /// let v = vec![b'a', b'b', b'c'];
+    /// let b = v.to_bstring();
+    /// println!("{b}");
+    /// assert_eq!(b, "abc");
+    /// assert_ne!(b, "hello");
+    /// ```
+    #[inline]
+    fn to_bstring(self) -> BString
+    where
+        Self: Sized,
+    {
+        BString::new(self.into_vec())
+    }
 
     /// Create a new owned byte string from the given byte slice.
     ///


### PR DESCRIPTION
- **ByteVec: Add a `to_bstring` method for convenient conversion to `BString`**
- **ByteVec: Add `as_bstring()` and `as_bstring_mut()` for in-place non-moving conversion to `BString`**
