### PR TITLE
Remove deprecated Error::description implementations

### DIFF
--- a/src/ext_vec.rs
+++ b/src/ext_vec.rs
@@ -1229,12 +1229,7 @@ impl FromUtf8Error {
 }
 
 #[cfg(feature = "std")]
-impl error::Error for FromUtf8Error {
-    #[inline]
-    fn description(&self) -> &str {
-        "invalid UTF-8 vector"
-    }
-}
+impl error::Error for FromUtf8Error {}
 
 impl fmt::Display for FromUtf8Error {
     #[inline]

--- a/src/utf8.rs
+++ b/src/utf8.rs
@@ -469,11 +469,7 @@ impl Utf8Error {
 }
 
 #[cfg(feature = "std")]
-impl std::error::Error for Utf8Error {
-    fn description(&self) -> &str {
-        "invalid UTF-8"
-    }
-}
+impl std::error::Error for Utf8Error {}
 
 impl fmt::Display for Utf8Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {


### PR DESCRIPTION
## Summary

- remove the explicit deprecated `Error::description` overrides from `Utf8Error` and `FromUtf8Error`
- retain both `Error` implementations and their existing `Display` formatting

Fixes #227.

## Testing

- `RUSTFLAGS="-D warnings" cargo build`
- `RUSTFLAGS="-D warnings" cargo doc`
- default, `serde`, and all supported no-default-feature build/test combinations
- `cargo test --all-features` (46 unit tests and 196 doc tests passed; 6 doc tests ignored)
- `cargo test --benches` in `bench`
- `cargo fmt --check`
- `git diff --check`
